### PR TITLE
Content Security Policy changed as per Manifest V3 and Service Worker file added 

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,13 +16,12 @@
     "contextMenus",
     "storage",
     "webRequest",
-    "offscreen",
-    "<all_urls>"
+    "offscreen"
   ],
   "content_scripts": [
     {
       "matches": [
-        "<all_urls>"
+        "*://*/*"
       ],
       "css": [
         "lib/oojs-ui-wikimediaui.min.css",
@@ -62,8 +61,13 @@
     }
   ],
   "background": {
-    "service_worker": "service_worker.js",
-    "type": "module"
+    "service_worker": "service-worker.js",
+    "scripts": [
+      "lib/browser-polyfill.min.js",
+      "lib/jquery.min.js",
+      "lib/banana-i18n.js",
+      "background-script.js"
+    ]
   },
   "web_accessible_resources": [
     {
@@ -76,7 +80,7 @@
     }
   ],
   "commands": {
-    "_execute_browser_action": {
+    "_execute_action": {
       "suggested_key": {
         "default": "Ctrl+Shift+L"
       }

--- a/manifest.json
+++ b/manifest.json
@@ -5,22 +5,18 @@
   "author": "Antoine '0x010C' Lamielle, Hugo Lopez",
   "description": "SignIt translate a selected word into Sign Language videos.",
   "homepage_url": "https://lingualibre.org",
-  "applications": {
-    "gecko": {
-      "id": "signit@lingualibre.fr"
-    }
-  },
   "icons": {
     "32": "icons/Lingualibre_SignIt-logo-no-text-square-32.png",
     "48": "icons/Lingualibre_SignIt-logo-no-text-square-48.png",
     "64": "icons/Lingualibre_SignIt-logo-no-text-square-64.png"
   },
   "permissions": [
+    "scripting",
     "activeTab",
     "contextMenus",
     "storage",
     "webRequest",
-    "webRequestBlocking",
+    "offscreen",
     "<all_urls>"
   ],
   "content_scripts": [
@@ -66,13 +62,9 @@
     }
   ],
   "background": {
-    "scripts": [
-        "lib/browser-polyfill.min.js",
-        "lib/jquery.min.js",
-        "lib/banana-i18n.js",
-        "background-script.js"
-    ]
-},
+    "service_worker": "service_worker.js",
+    "type": "module"
+  },
   "web_accessible_resources": [
     {
       "resources": [
@@ -91,7 +83,8 @@
     }
   },
   "content_security_policy": {
-    "extension_pages": "default-src 'self' data: https://lingualibre.org https://*.wikimedia.org https://*.wikipedia.org https://*.wiktionary.org; script-src 'self'; object-src 'self' https://commons.wikimedia.org; style-src 'self' 'unsafe-inline'; img-src 'self' data:"
+    "extension_pages": "default-src 'self' data: https://lingualibre.org https://*.wikimedia.org https://*.wikipedia.org https://*.wiktionary.org; script-src 'self';  style-src 'self' 'unsafe-inline'; img-src 'self' data",
+    "sandbox": "sandbox allow-scripts allow-forms allow-popups allow-modals; script-src 'self' 'unsafe-inline' 'unsafe-eval'; child-src 'self';"
   },
   "action": {
     "default_icon": "icons/Lingualibre_SignIt-logo-no-text-square-32.png",

--- a/service_worker.js
+++ b/service_worker.js
@@ -1,0 +1,150 @@
+// importScripts('lib/browser-polyfill.min.js');
+// importScripts('lib/jquery.min.js');
+// importScripts('lib/banana-i18n.js');
+// importScripts('background-script.js');
+
+// Define Sparql endpoints
+const sparqlEndpoints = {
+    lingualibre: { url: "https://lingualibre.org/bigdata/namespace/wdq/sparql", verb: "POST" },
+    wikidata: { url: "https://query.wikidata.org/sparql", verb: "GET" },
+    commons: { url: "https://commons-query.wikimedia.org/sparql", verb: "GET" },
+    dictionaireFrancophone: { url: "https://www.dictionnairedesfrancophones.org/sparql", verb: "" },
+};
+
+// Sparql queries
+const sparqlSignLanguagesQuery = 'SELECT ?id ?idLabel WHERE { ?id prop:P2 entity:Q4 . ?id prop:P24 entity:Q88890 . SERVICE wikibase:label { bd:serviceParam wikibase:language "fr,en". } }';
+const sparqlSignVideosQuery = 'SELECT ?word ?filename ?speaker WHERE { ?record prop:P2 entity:Q2 . ?record prop:P4 entity:$(lang) . ?record prop:P7 ?word . ?record prop:P3 ?filename . ?record prop:P5 ?speakerItem . ?speakerItem rdfs:label ?speaker filter ( lang( ?speaker ) = "en" ) . }';
+const sparqlFilesInCategoryQuery = `SELECT ?file ?url ?title
+WHERE {
+  SERVICE wikibase:mwapi {
+    bd:serviceParam wikibase:api "Generator" ;
+                    wikibase:endpoint "commons.wikimedia.org" ;
+                    mwapi:gcmtitle "Category:Videos Langue des signes française" ;
+                    mwapi:generator "categorymembers" ;
+                    mwapi:gcmtype "file" ;
+                    mwapi:gcmlimit "max" .
+    ?title wikibase:apiOutput mwapi:title .
+    ?pageid wikibase:apiOutput "@pageid" .
+  }
+  BIND (URI(CONCAT('https://commons.wikimedia.org/entity/M', ?pageid)) AS ?file)
+  BIND (URI(CONCAT('https://commons.wikimedia.org/wiki/', ?title)) AS ?url)
+}`;
+
+// Initial state
+let state = 'up';
+let records = {};
+let signLanguages = [];
+let uiLanguages = [];
+const params = {
+    signLanguage: 'Q99628',
+    uiLanguage: 'Q150',
+    historylimit: 6,
+    history: ['lapin', 'crabe', 'fraise', 'canard'],
+    wpintegration: true,
+    twospeed: true,
+    hinticon: true,
+    coloredwords: true,
+    choosepanels: 'both',
+};
+
+// Fetch data from Sparql endpoint
+async function fetchSparqlData(endpoint, query) {
+    try {
+        const response = await fetch(endpoint.url, {
+            method: endpoint.verb,
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+            },
+            body: new URLSearchParams({ query }),
+        });
+        const data = await response.json();
+        return data;
+    } catch (error) {
+        console.error(error);
+        throw new Error('Failed to fetch data from SPARQL endpoint');
+    }
+}
+
+// Get sign languages with videos
+async function getSignLanguagesWithVideos() {
+    try {
+        const response = await fetchSparqlData(sparqlEndpoints.lingualibre, sparqlSignLanguagesQuery);
+        const signLanguages = response.results.bindings.map(item => ({
+            wdQid: item.id.value.split('/').pop(),
+            labelNative: item.idLabel.value,
+        }));
+        return signLanguages.filter(language => language.wdQid === 'Q99628'); // Temporary filter
+    } catch (error) {
+        console.error(error);
+        throw new Error('Failed to fetch sign languages with videos');
+    }
+}
+
+// Get all records for a sign language
+async function getAllRecords(signLanguage) {
+    try {
+        const query = sparqlSignVideosQuery.replace('$(lang)', signLanguage);
+        const response = await fetchSparqlData(sparqlEndpoints.lingualibre, query);
+        const records = {};
+        response.results.bindings.forEach(record => {
+            const word = record.word.value.toLowerCase();
+            if (!records[word]) {
+                records[word] = [];
+            }
+            records[word].push({
+                filename: record.filename.value.replace('http://', 'https://'),
+                speaker: record.speaker.value,
+            });
+        });
+        return records;
+    } catch (error) {
+        console.error(error);
+        throw new Error('Failed to fetch all records');
+    }
+}
+
+// Handle messages from clients (e.g., pages or other workers)
+self.addEventListener('message', async event => {
+    const { command, payload } = event.data;
+    switch (command) {
+        case 'getSignLanguages':
+            try {
+                const signLanguages = await getSignLanguagesWithVideos();
+                self.postMessage({ command: 'signLanguages', payload: signLanguages });
+            } catch (error) {
+                console.error(error);
+                self.postMessage({ command: 'error', payload: 'Failed to fetch sign languages' });
+            }
+            break;
+        case 'getAllRecords':
+            try {
+                const records = await getAllRecords(payload.signLanguage);
+                self.postMessage({ command: 'records', payload: records });
+            } catch (error) {
+                console.error(error);
+                self.postMessage({ command: 'error', payload: 'Failed to fetch records' });
+            }
+            break;
+        // Add more cases for other commands
+        default:
+            break;
+    }
+});
+
+// Install event listener to initialize the service worker
+self.addEventListener('install', event => {
+    console.log('Service worker installed');
+    // Perform any initial setup here
+});
+
+// Activate event listener to activate the service worker
+self.addEventListener('activate', event => {
+    console.log('Service worker activated');
+    // Perform any necessary cleanup here
+});
+
+// Fetch event listener to handle incoming fetch requests
+self.addEventListener('fetch', event => {
+    console.log('Service worker fetching:', event.request.url);
+    // Handle fetch requests here
+});


### PR DESCRIPTION
This PR arose because of [issue#55](https://github.com/lingua-libre/SignIt/issues/55) . Apparently upon unpacking the extension file it showed
```
Failed to load extension
File 
~\Downloads\SignIt\SignIt-master
Error
'content_security_policy.extension_pages': Insecure CSP value "https://commons.wikimedia.org" in directive 'object-src'.
Could not load manifest.
```
The issue could have been resolved by simply removing `object-src 'self' https://commons.wikimedia.org;` from extension pages but I not only removed it but also updated it as per the syntax of manifest V3 which changed `extension_pages` to a dictionary and introduced the `sandbox` key. Now upon unpacking it won't show CSP related issues in chrome dev mode.

Regarding the `service worker file` , I have built it on top of old `background-script.js` using **GPT** so might not work as intended . . . feel free to make it work better 