### PR TITLE
Migration to service worker initiated

### DIFF
--- a/content_scripts/signit.js
+++ b/content_scripts/signit.js
@@ -232,7 +232,7 @@
 	var addHintIconEmit = function(){
 		if(!$('.signit-hint-container')[0]){ console.log("No hintIcon element! Create one.") } 
 		$(".signit-hint-container").on( "click", async function(){ 
-			iconText = getSelectionText();
+			var iconText = getSelectionText();
 			// var tabs = await browser.tabs.query({active: true, currentWindow: true});
 			// await checkActiveTabInjections( tabs[ 0 ].id );
 			browser.runtime.sendMessage({

--- a/manifest.json
+++ b/manifest.json
@@ -16,6 +16,7 @@
     "contextMenus",
     "storage",
     "webRequest",
+    "webRequestBlocking",
     "offscreen"
   ],
   "content_scripts": [

--- a/manifest.json
+++ b/manifest.json
@@ -11,18 +11,17 @@
 	  "64": "icons/Lingualibre_SignIt-logo-no-text-square-64.png"
 	},
 	"permissions": [
-	  "activeTab",
-	  "contextMenus",
-	  "storage",
-	  "webRequest",
-	  "webRequestBlocking",
-	  "scripting"
-	],
-	"host_permissions": [ "<all_urls>" ],
-	"content_scripts": [
-	  {
-		"matches": [
-		  "<all_urls>"
+    "scripting",
+    "activeTab",
+    "contextMenus",
+    "storage",
+    "webRequest",
+    "offscreen"
+  ],
+  "content_scripts": [
+    {
+      "matches": [
+        "*://*/*"
 		],
 		"css": [
 		  "lib/oojs-ui-wikimediaui.min.css",
@@ -62,7 +61,7 @@
 	  }
 	],
 	"background": {
-		"service_worker": "background-script.js",
+		"service_worker": "sw.js",
 		"scripts": [
 			"lib/browser-polyfill.min.js",
 			"lib/jquery.min.js",
@@ -81,15 +80,16 @@
 	  }
 	],
 	"commands": {
-	  "_execute_browser_action": {
-		"suggested_key": {
-		  "default": "Ctrl+Shift+L"
-		}
-	  }
-	},
+    "_execute_action": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+L"
+      }
+    }
+  },
   "content_security_policy": {
-	"extension_pages": "default-src 'self' data: https://lingualibre.org https://*.wikimedia.org https://*.wikipedia.org https://*.wiktionary.org; script-src 'self'; object-src 'self' https://*.wikimedia.org ; img-src 'self' https://*.wikimedia.org ; style-src 'self' 'unsafe-inline'; img-src 'self' data:"
-	},
+    "extension_pages": "default-src 'self' data: https://lingualibre.org https://*.wikimedia.org https://*.wikipedia.org https://*.wiktionary.org; script-src 'self';  style-src 'self' 'unsafe-inline'; img-src 'self' data",
+    "sandbox": "sandbox allow-scripts allow-forms allow-popups allow-modals; script-src 'self' 'unsafe-inline' 'unsafe-eval'; child-src 'self';"
+  },
   "action": {
     "default_icon": "icons/Lingualibre_SignIt-logo-no-text-square-32.png",
     "default_title": "Lingua Libre SignIt",

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -20,7 +20,7 @@
   	</div>
     <div id="popup-loaded"></div>
   </div>
-  <script src="../lib/browser-polyfill.min.js"></script>
+  <!-- <script src="../lib/browser-polyfill.min.js"></script> -->
   <script src="../lib/jquery.min.js"></script>
   <script src="../lib/oojs.jquery.min.js"></script>
   <script src="../lib/oojs-ui.min.js"></script>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -1,7 +1,19 @@
-var browser = browser || chrome;
+var browserType = (typeof browser !== 'undefined' && browser.runtime) ? 'firefox' :
+                  (typeof chrome !== 'undefined' && chrome.runtime) ? 'chrome' :
+                  'unknown';
 (async function() {
-	var ui,
+	var ui,_backgroundPage;
+	// This if statement is made so that we are able to communicate with background-scripts(now sw.js/service worker) by passing messages 
+	// since we cant directly do it in V3 in chrome ofc, (not complete yet but had to start somewhere) . . . while making sure that 
+	// old getBackgroundPage() script works fine with firefox 
+	if (browserType === 'chrome') {
+		// Use Chrome Extensions API,
+		_backgroundPage = await chrome.runtime.sendMessage({ action: "getBackground" });
+
+	} else if (browserType === 'firefox') {
+		// Use Firefox WebExtensions API
 		_backgroundPage = await browser.runtime.getBackgroundPage();
+	}
 
 	/* *********************************************************** */
 	// Master
@@ -344,8 +356,9 @@ var browser = browser || chrome;
 		ui.switchPanel( 'loaded' );
 	}
 
+	let state = _backgroundPage.state;
 	function waitWhileLoading() {
-		if ( _backgroundPage.state === 'ready' ) {
+		if (state === 'ready' ) {
 			ui = new UI();
 		} else {
 			setTimeout( waitWhileLoading, 100 );

--- a/sw.js
+++ b/sw.js
@@ -1,28 +1,52 @@
 /* *************************************************************** */
-/* Sparql endpoints *********************************************** */
-const sparqlEndpoints = {
-  lingualibre: {
-    url: "https://lingualibre.org/bigdata/namespace/wdq/sparql",
-    verb: "POST",
-  },
-  wikidata: { url: "https://query.wikidata.org/sparql", verb: "GET" },
-  commons: { url: "https://commons-query.wikimedia.org/sparql", verb: "GET" },
-  dictionaireFrancophone: {
-    url: "https://www.dictionnairedesfrancophones.org/sparql",
-    verb: "",
-  },
-};
-/* *************************************************************** */
-/* Sparql ******************************************************** */
-// Lingualibre: All languages (P4) for which media type (P24) is video (Q88890)
-// TODO: NEEDS QUERY HITING ON LLQS+WDQS, FETCHING NATIVE NAME (P1705)
-const sparqlSignLanguagesQuery =
-  'SELECT ?id ?idLabel WHERE { ?id prop:P2 entity:Q4 . ?id prop:P24 entity:Q88890 . SERVICE wikibase:label { bd:serviceParam wikibase:language "fr,en". } }';
-// Lingualibre: Given a language (P4) with media video, fetch the list of writen word (P7), url (P3) speakers (P5)
-const sparqlSignVideosQuery =
-  'SELECT ?word ?filename ?speaker WHERE { ?record prop:P2 entity:Q2 . ?record prop:P4 entity:$(lang) . ?record prop:P7 ?word . ?record prop:P3 ?filename . ?record prop:P5 ?speakerItem . ?speakerItem rdfs:label ?speaker filter ( lang( ?speaker ) = "en" ) . }';
-// Wikidata: All Sign languages who have a Commons lingualibre category
-const sparqlFilesInCategoryQuery = `SELECT ?file ?url ?title
+/* TODO ********************************************************** */
+// See https://github.com/lingua-libre/SignIt/issues
+
+/* Phases ******************************************************** */
+// state: up
+// listen to event 1
+// loading saved params from localstorage
+// state: loading
+// loading available sign languages
+// loading vidéos urls
+// create context menu
+// state: ready
+
+// change language asked from popup box
+// update global var
+// state: loading
+// loading vidéos urls
+// set local storage
+// state: ready
+
+// can use type:"module" but it interferes with the working of extension in FF, hence using old importScripts
+
+importScripts("./lib/banana-i18n.js");
+  /* *************************************************************** */
+  /* Sparql endpoints *********************************************** */
+  const sparqlEndpoints = {
+    lingualibre: {
+      url: "https://lingualibre.org/bigdata/namespace/wdq/sparql",
+      verb: "POST",
+    },
+    wikidata: { url: "https://query.wikidata.org/sparql", verb: "GET" },
+    commons: { url: "https://commons-query.wikimedia.org/sparql", verb: "GET" },
+    dictionaireFrancophone: {
+      url: "https://www.dictionnairedesfrancophones.org/sparql",
+      verb: "",
+    },
+  };
+  /* *************************************************************** */
+  /* Sparql ******************************************************** */
+  // Lingualibre: All languages (P4) for which media type (P24) is video (Q88890)
+  // TODO: NEEDS QUERY HITING ON LLQS+WDQS, FETCHING NATIVE NAME (P1705)
+  const sparqlSignLanguagesQuery =
+    'SELECT ?id ?idLabel WHERE { ?id prop:P2 entity:Q4 . ?id prop:P24 entity:Q88890 . SERVICE wikibase:label { bd:serviceParam wikibase:language "fr,en". } }';
+  // Lingualibre: Given a language (P4) with media video, fetch the list of writen word (P7), url (P3) speakers (P5)
+  const sparqlSignVideosQuery =
+    'SELECT ?word ?filename ?speaker WHERE { ?record prop:P2 entity:Q2 . ?record prop:P4 entity:$(lang) . ?record prop:P7 ?word . ?record prop:P3 ?filename . ?record prop:P5 ?speakerItem . ?speakerItem rdfs:label ?speaker filter ( lang( ?speaker ) = "en" ) . }';
+  // Wikidata: All Sign languages who have a Commons lingualibre category
+  const sparqlFilesInCategoryQuery = `SELECT ?file ?url ?title
 WHERE {
   SERVICE wikibase:mwapi {
     bd:serviceParam wikibase:api "Generator" ;
@@ -38,171 +62,748 @@ WHERE {
   BIND (URI(CONCAT('https://commons.wikimedia.org/wiki/', ?title)) AS ?url)
 }`;
 
-/* *************************************************************** */
-/* Initial state if no localStorage ********************************* */
-var state = "up", // up, loading, ready, error
-  records = {},
-  signLanguages = [],
-  uiLanguages = [],
-  // Default values, will be stored in localStorage as well for persistency.
-  params = {
-    signLanguage: "Q99628", // for videos : French Sign language
-    uiLanguage: "Q150", // for interface : French
-    historylimit: 6,
-    history: ["lapin", "crabe", "fraise", "canard"], // Some fun
-    wpintegration: true,
-    twospeed: true,
-    hinticon: true,
-    coloredwords: true,
-    choosepanels: "both", // issues/36
-  };
+  var browser = chrome;
 
-// Get sign languages covered by Lingualibre
-// returns: [{ wdQid: "Q99628", labelNative: "langue des signes française"},{},...]
-async function getSignLanguagesWithVideos() {
-  var i,
-    signLanguage,
-    signLanguages = [], // ?? already define in global scopte
-    response = await $.post(sparqlEndpoints.lingualibre.url, {
-      format: "json",
-      query: sparqlSignLanguagesQuery,
-    });
-  // create signLanguages objects
-  for (i = 0; i < response.results.bindings.length; i++) {
-    var signLanguageRaw = response.results.bindings[i];
-    console.log("#149", signLanguageRaw);
-    signLanguage = {
-      wdQid: signLanguageRaw.id.value.split("/").pop(),
-      labelNative: signLanguageRaw.idLabel.value,
+  /* *************************************************************** */
+  /* Initial state if no localStorage ********************************* */
+  var state = "up", // up, loading, ready, error
+    records = {},
+    signLanguages = [],
+    uiLanguages = [],
+    // Default values, will be stored in localStorage as well for persistency.
+    params = {
+      signLanguage: "Q99628", // for videos : French Sign language
+      uiLanguage: "Q150", // for interface : French
+      historylimit: 6,
+      history: ["lapin", "crabe", "fraise", "canard"], // Some fun
+      wpintegration: true,
+      twospeed: true,
+      hinticon: true,
+      coloredwords: true,
+      choosepanels: "both", // issues/36
     };
-    signLanguages[i] = signLanguage;
-  }
-  // TEMPORARY, WHEN ONLY LSF HAS VIDEOS
-  signLanguages = filterArrayBy(signLanguages, "wdQid", "Q99628");
-  console.log(signLanguages);
 
-  return signLanguages;
-}
+  /* *************************************************************** */
+  /* i18n context ************************************************** */
+  // List of UI languages with translations on github via translatewiki
+  var supportedUiLanguages = [
+    {
+      i18nCode: "anp",
+      labelEN: "Angika",
+      labelNative: "अंगिका",
+      wdQid: "Q28378",
+      wiki: "anp",
+    },
+    {
+      i18nCode: "ar",
+      labelEN: "Arabic",
+      labelNative: "اللُّغَة العَرَبِيّة",
+      wdQid: "Q13955",
+      wiki: "ar",
+    },
+    {
+      i18nCode: "bn",
+      labelEN: "Bengali",
+      labelNative: "বাংলা",
+      wdQid: "Q9610",
+      wiki: "bn",
+    },
+    {
+      i18nCode: "blk",
+      labelEN: "Pa'O",
+      labelNative: "ပအိုဝ်ႏဘာႏသာႏ",
+      wdQid: "",
+      wiki: "Q7121294",
+    },
+    {
+      i18nCode: "br",
+      labelEN: "Breton",
+      labelNative: "Brezhoneg",
+      wdQid: "Q12107",
+      wiki: "br",
+    },
+    {
+      i18nCode: "ce",
+      labelEN: "Chechen",
+      labelNative: "Нохчийн мотт",
+      wdQid: "Q33350",
+      wiki: "ce",
+    },
+    {
+      i18nCode: "de",
+      labelEN: "German",
+      labelNative: "Deutsch",
+      wdQid: "Q188",
+      wiki: "de",
+    },
+    {
+      i18nCode: "en",
+      labelEN: "English",
+      labelNative: "English",
+      wdQid: "Q1860",
+      wiki: "en",
+    },
+    {
+      i18nCode: "es",
+      labelEN: "Spanish",
+      labelNative: "Español",
+      wdQid: "Q1321",
+      wiki: "es",
+    },
+    {
+      i18nCode: "fa",
+      labelEN: "Persian",
+      labelNative: "فارسی",
+      wdQid: "Q9168",
+      wiki: "fa",
+    },
+    {
+      i18nCode: "fi",
+      labelEN: "Finnish",
+      labelNative: "Suomi",
+      wdQid: "Q1412",
+      wiki: "fi",
+    },
+    {
+      i18nCode: "fr",
+      labelEN: "French",
+      labelNative: "Français",
+      wdQid: "Q150",
+      wiki: "fr",
+    },
+    {
+      i18nCode: "gl",
+      labelEN: "Galician",
+      labelNative: "Galego",
+      wdQid: "Q9307",
+      wiki: "gl",
+    },
+    {
+      i18nCode: "he",
+      labelEN: "Hebrew",
+      labelNative: "עברית",
+      wdQid: "Q9288",
+      wiki: "he",
+    },
+    {
+      i18nCode: "hi",
+      labelEN: "Hindi",
+      labelNative: "हिन्दी",
+      wdQid: "Q1568",
+      wiki: "hi",
+    },
+    {
+      i18nCode: "hu",
+      labelEN: "Hungarian",
+      labelNative: "Magyar",
+      wdQid: "Q9067",
+      wiki: "hu",
+    },
+    {
+      i18nCode: "ia",
+      labelEN: "Interlingua",
+      labelNative: "Interlingua",
+      wdQid: "Q35934",
+      wiki: "ia",
+    },
+    {
+      i18nCode: "id",
+      labelEN: "Indonesian",
+      labelNative: "Bahasa Indonesia",
+      wdQid: "Q9240",
+      wiki: "id",
+    },
+    {
+      i18nCode: "it",
+      labelEN: "Italian",
+      labelNative: "Italiano",
+      wdQid: "Q652",
+      wiki: "it",
+    },
+    {
+      i18nCode: "ja",
+      labelEN: "Japanese",
+      labelNative: "日本語",
+      wdQid: "Q5287",
+      wiki: "ja",
+    },
+    {
+      i18nCode: "kk-cyrl",
+      labelEN: "Kazakh",
+      labelNative: "Казақша",
+      wdQid: "Q9252",
+      wiki: "kk",
+    },
+    {
+      i18nCode: "ko",
+      labelEN: "Korean",
+      labelNative: "한국어",
+      wdQid: "Q9176",
+      wiki: "ko",
+    },
+    {
+      i18nCode: "krc",
+      labelEN: "Karachay-Balkar",
+      labelNative: "Qaraçay-malqar",
+      wdQid: "Q33714",
+      wiki: "krc",
+    },
+    {
+      i18nCode: "lmo",
+      labelEN: "Lombard",
+      labelNative: "Lengua lombarda",
+      wdQid: "Q33754",
+      wiki: "lmo",
+    },
+    {
+      i18nCode: "mk",
+      labelEN: "Macedonian",
+      labelNative: "Македонски",
+      wdQid: "Q9296",
+      wiki: "mk",
+    },
+    {
+      i18nCode: "mnw",
+      labelEN: "Mon",
+      labelNative: "ဘာသာမန်",
+      wdQid: "Q13349",
+      wiki: "mnw",
+    },
+    {
+      i18nCode: "ms",
+      labelEN: "Malay",
+      labelNative: "Bahasa Melayu",
+      wdQid: "Q9237",
+      wiki: "ms",
+    },
+    {
+      i18nCode: "nb",
+      labelEN: "Bokmål",
+      labelNative: "Bokmål",
+      wdQid: "Q25167",
+      wiki: "nb",
+    },
+    {
+      i18nCode: "pnb",
+      labelEN: "Western Punjabi",
+      labelNative: "ਪੰਜਾਬੀ",
+      wdQid: "Q1389492",
+    },
+    {
+      i18nCode: "pt",
+      labelEN: "Portuguese",
+      labelNative: "Português (pt)",
+      wdQid: "Q5146",
+      wiki: "pt",
+    },
+    {
+      i18nCode: "pt-br",
+      labelEN: "Portuguese",
+      labelNative: "Português (br)",
+      wdQid: "Q5146",
+      wiki: "pt",
+    },
+    {
+      i18nCode: "ru",
+      labelEN: "Russian",
+      labelNative: "Русский язык",
+      wdQid: "Q7737",
+      wiki: "ru",
+    },
+    {
+      i18nCode: "scn",
+      labelEN: "Sicilian",
+      labelNative: "Sicilianu",
+      wdQid: "Q33973",
+      wiki: "scn",
+    },
+    {
+      i18nCode: "sl",
+      labelEN: "Slovene",
+      labelNative: "Slovenski jezik",
+      wdQid: "Q9063",
+      wiki: "sl",
+    },
+    {
+      i18nCode: "sv",
+      labelEN: "Swedish",
+      labelNative: "Svenska",
+      wdQid: "Q9027",
+      wiki: "sv",
+    },
+    {
+      i18nCode: "sw",
+      labelEN: "Swahili",
+      labelNative: "Kiswahili",
+      wdQid: "Q7838",
+      wiki: "sw",
+    },
+    {
+      i18nCode: "tl",
+      labelEN: "Tagalog",
+      labelNative: "Wikang Tagalog",
+      wdQid: "Q34057",
+      wiki: "tl",
+    },
+    {
+      i18nCode: "tr",
+      labelEN: "Turkish",
+      labelNative: "Türkçe",
+      wdQid: "Q256",
+      wiki: "tr",
+    },
+    {
+      i18nCode: "uk",
+      labelEN: "Ukrainian",
+      labelNative: "Українська мова",
+      wdQid: "Q8798",
+      wiki: "uk",
+    },
+    // {i18nCode:"zh",labelEN: "Chinese",labelNative: "汉语",wdQid: "Q7850",wiki: "zh"}
+    {
+      i18nCode: "zh-hant",
+      labelEN: "Traditional Chinese",
+      labelNative: "中文 (繁體)",
+      wdQid: "Q18130932",
+      wiki: "zh",
+    },
+    {
+      i18nCode: "zh-hans",
+      labelEN: "Modern Chinese",
+      labelNative: "中文 (简体)",
+      wdQid: "Q13414913",
+      wiki: "zh",
+    },
+  ];
 
-/* *************************************************************** */
-/* Settings management : memory, updates ************************* */
-// Save parameter and value in localStorage
-async function storeParam(name, value) {
-  // If value of type array, we make a copy of it to avoid dead references issues
-  if (Array.isArray(value)) {
-    value = Array.from(value); // copy
-  }
-  // else, create object { name: value }
-  console.log("HERE ! Selected option: { ", name + ": " + value + " }");
-  var tmp = {};
-  tmp[name] = value;
-  // reset params
-  params[name] = value;
-  return await chrome.storage.local.set(tmp);
-}
-
-// Get stored values from init hard coded `params` or from prefered local storage
-// Also synchronize both.
-async function getStoredParam(name) {
-  var tmp = await chrome.storage.local.get(name);
-  params[name] = tmp[name] || params[name] || null;
-  // If missing from local storage, then save init values in local storage
-  if (tmp.length == undefined) {
-    await storeParam(name, params[name]);
-  }
-  return params[name];
-}
-
-// Loading all vidéos of a given sign language. Format:
-// returns format: { word: { filename: url, speaker: name }, ... };
-async function getAllRecords(signLanguage) {
-  var i,
-    record,
-    word,
-    response,
-    records = {};
-
-  state = "loading";
-
-  response = await $.post(sparqlEndpoints.lingualibre.url, {
-    format: "json",
-    query: sparqlSignVideosQuery.replace("$(lang)", signLanguage),
+  // Init internationalisation support with Banana-i18n.js
+  var banana = new Banana("fr"); // use document browser language
+  loadI18nLocalization(params.uiLanguage);
+  // Add url support
+  banana.registerParserPlugin("link", (nodes) => {
+    return '<a href="' + nodes[0] + '">' + nodes[1] + "</a>";
   });
 
-  for (i = 0; i < response.results.bindings.length; i++) {
-    record = response.results.bindings[i];
-    word = record.word.value.toLowerCase();
-    if (records.hasOwnProperty(word) === false) {
-      records[word] = [];
+  /* ************************************************ 
+async function fetchJS(filepath) {
+	try {
+		const response = await fetch(`${filepath}`, {
+			method: 'GET',
+			credentials: 'same-origin'
+		});
+		const content = await response.json();
+		return content;
+	} catch (error) { console.error(error); }
+}
+messages = await fetchJS(`i18n/${locale}.json`); */
+
+  // Loading all UI translations
+  async function loadI18nLocalization(uiLanguageQid) {
+    var localizedPhrases = {};
+
+    console.log("uiLanguageQid)", uiLanguageQid);
+    console.log("supportedUiLanguages", supportedUiLanguages);
+
+    state = "loading";
+
+    // Get locale code and corresponding wiktionary
+    var lang = supportedUiLanguages.filter(
+      (item) => item.wdQid == uiLanguageQid
+    );
+    var locale = lang[0].i18nCode;
+    console.log("locale", locale);
+
+    // Load i18n messages
+    const res = await fetch(`i18n/${locale}.json`);
+    localizedPhrases = await res.json();
+    console.log("messages", localizedPhrases["si-popup-settings-title"]);
+    // Load messages into localisation
+    banana.load(localizedPhrases, locale); // Load localized messages (chould be conditional to empty)
+
+    // Declare localisation
+    banana.setLocale(locale); // Change to new locale
+    storeParam("bananaInStore", banana);
+
+    state = "ready";
+
+    console.log(Object.keys(localizedPhrases).length + " i18n messages loaded");
+  }
+  /* *************************************************************** */
+  /* Settings management : memory, updates ************************* */
+  // Save parameter and value in localStorage
+  async function storeParam(name, value) {
+    // If value of type array, we make a copy of it to avoid dead references issues
+    if (Array.isArray(value)) {
+      value = Array.from(value); // copy
     }
-    records[word].push({
-      filename: record.filename.value.replace("http://", "https://"),
-      speaker: record.speaker.value,
+    // else, create object { name: value }
+    console.log("HERE ! Selected option: { ", name + ": " + value + " }");
+    var tmp = {};
+    tmp[name] = value;
+    // reset params
+    params[name] = value;
+    return await browser.storage.local.set(tmp);
+  }
+  // Get stored values from init hard coded `params` or from prefered local storage
+  // Also synchronize both.
+  async function getStoredParam(name) {
+    var tmp = await browser.storage.local.get(name);
+    params[name] = tmp[name] || params[name] || null;
+    // If missing from local storage, then save init values in local storage
+    if (tmp.length == undefined) {
+      await storeParam(name, params[name]);
+    }
+    return params[name];
+  }
+
+  // Get sign languages covered by Lingualibre
+  // returns: [{ wdQid: "Q99628", labelNative: "langue des signes française"},{},...]
+  // async function getSignLanguagesWithVideos() {
+  // 	var i,
+  // 		signLanguage,
+  // 		signLanguages = [], // ?? already define in global scopte
+  // 		response = await $.post(
+  // 			sparqlEndpoints.lingualibre.url,
+  // 			{ format: 'json', query: sparqlSignLanguagesQuery }
+  // 		);
+  // 		for ( i = 0; i < response.results.bindings.length; i++ ) {
+  // 			var signLanguageRaw = response.results.bindings[ i ];
+  // 			console.log("#149",signLanguageRaw)
+  // 			signLanguage = { wdQid: signLanguageRaw.id.value.split( '/' ).pop(), labelNative: signLanguageRaw.idLabel.value }
+  // 			signLanguages[i] = signLanguage;
+  // 		}
+  // 	// create signLanguages objects
+  // 	// TEMPORARY, WHEN ONLY LSF HAS VIDEOS
+  // 	signLanguages = filterArrayBy(signLanguages,"wdQid", "Q99628");
+  // 	console.log(signLanguages)
+
+  // 	return signLanguages;
+  // }
+
+  async function getSignLanguagesWithVideos() {
+    try {
+      const response = await fetch(sparqlEndpoints.lingualibre.url, {
+        method: "POST",
+        body: JSON.stringify({
+          format: "json",
+          query: sparqlSignLanguagesQuery,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const data = await response.json(); // Await the parsed JSON response
+
+      const signLanguages = [];
+      for (let i = 0; i < data.results.bindings.length; i++) {
+        const signLanguageRaw = data.results.bindings[i];
+        const signLanguage = {
+          wdQid: signLanguageRaw.id.value.split("/").pop(),
+          labelNative: signLanguageRaw.idLabel.value,
+        };
+        signLanguages.push(signLanguage);
+      }
+
+      // Temporary filtering (assuming filterArrayBy is available)
+      signLanguages = filterArrayBy(signLanguages, "wdQid", "Q99628");
+
+      console.log(signLanguages);
+      return signLanguages;
+    } catch (error) {
+      console.error("Error fetching or processing data:", error);
+    }
+  }
+
+  // Loading all vidéos of a given sign language. Format:
+  // returns format: { word: { filename: url, speaker: name }, ... };
+  async function getAllRecords(signLanguage) {
+    // response = await $.post( sparqlEndpoints.lingualibre.url, { format: 'json', query: sparqlSignVideosQuery.replace( '$(lang)', signLanguage ) } );
+    
+    // Using Fetch API since service_worker cant access DOM and hence cant use jquery
+
+    var i,
+      record,
+      word,
+      response,
+      records = {};
+    try {
+      state = "loading";
+
+      response = await fetch(sparqlEndpoints.lingualibre.url, {
+        method: "POST",
+        body: JSON.stringify({
+          format: "json",
+          query: sparqlSignVideosQuery.replace("$(lang)", signLanguage),
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const data = await response.json(); // Await the parsed JSON response
+
+      for (i = 0; i < data.results.bindings.length; i++) {
+        record = data.results.bindings[i];
+        word = record.word.value.toLowerCase();
+        if (records.hasOwnProperty(word) === false) {
+          records[word] = [];
+        }
+        records[word].push({
+          filename: record.filename.value.replace("http://", "https://"),
+          speaker: record.speaker.value,
+        });
+      }
+
+      state = "ready";
+
+      console.log(Object.keys(records).length + " records loaded");
+      return records;
+    } catch (error) {
+      console.error("Error fetching or processing data:", error);
+    }
+  }
+
+  // Given language's Qid, reload list of available videos and records/words data
+  async function changeLanguage(newLang) {
+    records = await getAllRecords(newLang);
+    await storeParam("signLanguage", newLang); // localStorage save
+  }
+
+  // Given language's Qid, reload available translations
+  async function changeUiLanguage(newLang) {
+    console.log("changeUiLanguage newLang", newLang); // => 'Q150' for french
+    messages = await loadI18nLocalization(newLang);
+    await storeParam("uiLanguage", newLang); // localStorage save
+  }
+
+  /* *************************************************************** */
+  /* Toolbox functions ********************************************* */
+  var filterArrayBy = function (arr, key, value) {
+    return arr.filter((item) => item[key] == value);
+  };
+  function normalize(selection) {
+    // this could do more
+    return selection.trim();
+  }
+
+  // Check a string with multiple words and return the word whose record is available
+  function getAvailableWord(word) {
+    const wordArray = word.split(" ");
+    // For some reason iterating through array returns undefined so I switched to filter method
+
+    // for ( let newWord of wordArray ) {
+    // 	if( records.hasOwnProperty(newWord.toLowerCase()) ){
+    // 		return newWord;
+    // 	}
+    // }
+    wordArray.filter((e) => {
+      if (records.hasOwnProperty(e.toLowerCase())) return e;
     });
+    return wordArray[0];
   }
 
-  state = "ready";
+  // Given a word string, check if exist in available records data, if so return data on that word
+  // returns format: { filename: url, speaker: name }
+  function wordToFiles(word) {
+    var fileData = records.hasOwnProperty(word)
+      ? records[word]
+      : records.hasOwnProperty(word.toLowerCase())
+      ? records[word.toLowerCase()]
+      : null;
+    return fileData;
+  }
 
-  console.log(Object.keys(records).length + " records loaded");
-  return records;
-}
+  var normalizeMessage = function (msg) {
+    var text = msg.selectionText || msg.iconText || msg.wpTitle;
+    delete msg.selectionText; // when from background-script.js via right-click menu
+    delete msg.iconText; // when from signit.js icon click
+    delete msg.wpTitle; // when from wpintegration.js auto-injection
+    // text = text.trim();
+    const newMsg = { ...msg, text };
+    // msg.list = getAllRecords() <--------- how to do
+    return newMsg;
+  };
 
-// Given language's Qid, reload list of available videos and records/words data
-async function changeLanguage(newLang) {
-  records = await getAllRecords(newLang);
-  await storeParam("signLanguage", newLang); // localStorage save
-}
+  /* *************************************************************** */
+  /* Dependencies, CSP ********************************************* */
+  async function getActiveTabId() {
+    await browser.tabs.query({ active: true, currentWindow: true });
+    return tabs[0].id;
+  }
+  // Ping tab, if fails, then CSS, JS dependencies loaded and executed
+  async function checkActiveTabInjections(tabId) {
+    try {
+      await browser.tabs.sendMessage(tabId, { command: "ping" });
+    } catch (error) {
+      // var i,
+      var dependencies = browser.runtime.getManifest().content_scripts[0];
+      var scripts = dependencies.js;
+      var stylesheets = dependencies.css;
 
-function normalize(selection) {
-  // this could do more
-  return selection.trim();
-}
+      // Using the scripting API as per Manifest V3
 
-function wordToFiles(word) {
-  var fileData = records.hasOwnProperty(word)
-    ? records[word]
-    : records.hasOwnProperty(word.toLowerCase())
-    ? records[word.toLowerCase()]
-    : null;
-  return fileData;
-}
-
-/* *************************************************************** */
-/* Main ********************************************************** */
-async function main() {
-  state = "loading";
-
-  // Get local storage value if exist, else get default values
-  // promise.all
-  // await getStoredParam( 'history' );
-  // await getStoredParam( 'historylimit' );
-  // await getStoredParam( 'wpintegration' );
-  // await getStoredParam( 'twospeed' );
-  // storeParam( 'twospeed', params.twospeed ); //
-  // await getStoredParam( 'hinticon' );
-  // await getStoredParam( 'coloredwords' );
-  // await getStoredParam( 'choosepanels' );
-
-  signLanguage = await getStoredParam("signLanguage");
-  signLanguages = await getSignLanguagesWithVideos();
-  // uiLanguage = await getStoredParam( 'uiLanguage' );
-  // console.log("supportedUiLanguages",supportedUiLanguages)
-  // uiLanguages = supportedUiLanguages;
-  records = await getAllRecords(signLanguage);
-
-  state = "ready";
-}
-// main();
-chrome.runtime.onMessage.addListener(async (message, sender, sendResponse) => {
-  try {
-    await main(); // Call main function to populate data
-    console.log("Received message:", message);
-    if (message.type === "getBackground") {
-      sendResponse(message); // Send appropriate response
-    } else {
-      sendResponse("error received");
+      // for( i = 0; i < scripts.length; i++ ) {
+      // await browser.scripting.executeScript( tab, { file: scripts[ i ] } );
+      await browser.scripting.executeScript({
+        target: { tabId },
+        files: [...scripts],
+      });
+      // }
+      // for( i = 0; i < stylesheets.length; i++ ) {
+      // await browser.tabs.insertCSS( tab, { file: stylesheets[ i ] } );
+      await browser.scripting.insertCSS({
+        target: { tabId },
+        files: [...stylesheets],
+      });
+      // }
     }
-  } catch (error) {
-    sendResponse("error occurred");
   }
+
+// Insecure CSP not supported in manifest V3 , so no need to for the bypass logic
+
+  // Edit the header of all pages on-the-fly to bypass Content-Security-Policy
+  // browser.webRequest.onHeadersReceived.addListener(info => {
+  //     const headers = info.responseHeaders; // original headers
+  //     for (let i=headers.length-1; i>=0; --i) {
+  //         let header = headers[i].name.toLowerCase();
+  //         if (header === "content-security-policy") { // csp header is found
+  //             // modifying media-src; this implies that the directive is already present
+  //             headers[i].value = headers[i].value.replace("media-src", "media-src https://commons.wikimedia.org https://upload.wikimedia.org");
+  //         }
+  //     }
+  //     // return modified headers
+  //     return {responseHeaders: headers};
+  // }, {
+  //     urls: [ "<all_urls>" ], // match all pages
+  //     types: [ "main_frame" ] // to focus only the main document of a tab
+  // }, ["blocking", "responseHeaders"]);
+
+  /* *************************************************************** */
+  /* Browser interactions ****************************************** */
+  var callModal = async function (msg) {
+    // Tab
+    console.log("Call modal > msg", { msg });
+    var tabs = await browser.tabs.query({ active: true, currentWindow: true });
+    await checkActiveTabInjections(tabs[0].id);
+    console.log("Call modal > #282 > tab id", tabs[0].id);
+    // Data
+    var word = msg.text;
+    if (word.split(" ").length > 1) {
+      word = getAvailableWord(word);
+    }
+    var videosFiles = msg.files || wordToFiles(word) || [];
+    // Send message which opens the modal
+    browser.tabs.sendMessage(tabs[0].id, {
+      command: "signit.sign",
+      text: word,
+      files: videosFiles,
+      supportedWords: Object.keys(records), // <------ array for coloredwords feature
+      banana: banana,
+    });
+    storeParam("history", [word, ...params.history]);
+  };
+
+  // Create a context menu item (right-click on text to see)
+  browser.contextMenus.create(
+    {
+      id: "signit",
+      title: "Lingua Libre SignIt",
+      contexts: ["selection"],
+    },
+    function () {
+      return;
+    }
+  );
+
+  // Listen for right-click menu's signals
+  browser.contextMenus.onClicked.addListener(async function (
+    menuMessage,
+    __tab
+  ) {
+    // var tab not used ? Can remove ?
+    let message = normalizeMessage(menuMessage);
+    callModal(message);
+  });
+
+  // Listen for other signals
+  browser.runtime.onMessage.addListener(async function (
+    message,
+    sender,
+    sendResponse
+  ) {
+    console.log(
+      "Message heard in service_worker: ",
+      message,
+      "---------------------"
+    );
+    message = normalizeMessage(message);
+
+    // When message 'signit.getfiles' is heard, returns relevant extract of records[]
+    if (message.command === "signit.getfiles") {
+      console.log("bg>signit.getfiles");
+      console.log(
+        records[message.text] || records[message.text.toLowerCase()] || []
+      );
+      return records[message.text] || records[message.text.toLowerCase()] || [];
+    }
+    // When message 'signit.i18nCode' is heard, returns banada object
+    else if (
+      message.command === "signit.getfilesb" ||
+      message.command === "getBanana"
+    ) {
+      console.log("bg>signit.getfilesB");
+	// var locale = await getStoredParam( 'uiLanguage' )
+	// loadI18nLocalization(locale);
+	//   return banana;
+    
+  // What this does is it accesses the messageStore inside banana amd spreads the sourecMap
+  // which is an instanceof Map thereby converting it into an array. This is later recreated inside popup
+      sendResponse([...banana.messageStore.sourceMap]);
+    }
+
+    // Start modal
+    // When right click's menu "Lingua Libre SignIt" clicked, send message 'signit.sign' to the content script => opens Signit modal
+    else if (message.command === "signit.hinticon") {
+      callModal(message);
+    }
+  });
+
+  /* *************************************************************** */
+  /* Main ********************************************************** */
+  async function main() {
+    state = "loading";
+
+    // Get local storage value if exist, else get default values
+    // promise.all
+    await getStoredParam("history");
+    await getStoredParam("historylimit");
+    await getStoredParam("wpintegration");
+    await getStoredParam("twospeed");
+    // storeParam( 'twospeed', params.twospeed ); //
+    await getStoredParam("hinticon");
+    await getStoredParam("coloredwords");
+    await getStoredParam("choosepanels");
+
+    let signLanguage = await getStoredParam("signLanguage");
+    // signLanguages = await getSignLanguagesWithVideos();
+    let uiLanguage = await getStoredParam("uiLanguage");
+    console.log("supportedUiLanguages", supportedUiLanguages);
+    uiLanguages = supportedUiLanguages;
+    // records = await getAllRecords( signLanguage );
+
+    state = "ready";
+  }
+
+// Run it
+main();
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+	if (message.command === "getBackground") {
+    // temporary fix , needs to be persisted in chrome.storage.local but will get to that later
+    const a = {state:"ready",params};
+    sendResponse(a);
+	}
 });

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,208 @@
+/* *************************************************************** */
+/* Sparql endpoints *********************************************** */
+const sparqlEndpoints = {
+  lingualibre: {
+    url: "https://lingualibre.org/bigdata/namespace/wdq/sparql",
+    verb: "POST",
+  },
+  wikidata: { url: "https://query.wikidata.org/sparql", verb: "GET" },
+  commons: { url: "https://commons-query.wikimedia.org/sparql", verb: "GET" },
+  dictionaireFrancophone: {
+    url: "https://www.dictionnairedesfrancophones.org/sparql",
+    verb: "",
+  },
+};
+/* *************************************************************** */
+/* Sparql ******************************************************** */
+// Lingualibre: All languages (P4) for which media type (P24) is video (Q88890)
+// TODO: NEEDS QUERY HITING ON LLQS+WDQS, FETCHING NATIVE NAME (P1705)
+const sparqlSignLanguagesQuery =
+  'SELECT ?id ?idLabel WHERE { ?id prop:P2 entity:Q4 . ?id prop:P24 entity:Q88890 . SERVICE wikibase:label { bd:serviceParam wikibase:language "fr,en". } }';
+// Lingualibre: Given a language (P4) with media video, fetch the list of writen word (P7), url (P3) speakers (P5)
+const sparqlSignVideosQuery =
+  'SELECT ?word ?filename ?speaker WHERE { ?record prop:P2 entity:Q2 . ?record prop:P4 entity:$(lang) . ?record prop:P7 ?word . ?record prop:P3 ?filename . ?record prop:P5 ?speakerItem . ?speakerItem rdfs:label ?speaker filter ( lang( ?speaker ) = "en" ) . }';
+// Wikidata: All Sign languages who have a Commons lingualibre category
+const sparqlFilesInCategoryQuery = `SELECT ?file ?url ?title
+WHERE {
+  SERVICE wikibase:mwapi {
+    bd:serviceParam wikibase:api "Generator" ;
+                    wikibase:endpoint "commons.wikimedia.org" ;
+                    mwapi:gcmtitle "Category:Videos Langue des signes française" ;
+                    mwapi:generator "categorymembers" ;
+                    mwapi:gcmtype "file" ;
+                    mwapi:gcmlimit "max" .
+    ?title wikibase:apiOutput mwapi:title .
+    ?pageid wikibase:apiOutput "@pageid" .
+  }
+  BIND (URI(CONCAT('https://commons.wikimedia.org/entity/M', ?pageid)) AS ?file)
+  BIND (URI(CONCAT('https://commons.wikimedia.org/wiki/', ?title)) AS ?url)
+}`;
+
+/* *************************************************************** */
+/* Initial state if no localStorage ********************************* */
+var state = "up", // up, loading, ready, error
+  records = {},
+  signLanguages = [],
+  uiLanguages = [],
+  // Default values, will be stored in localStorage as well for persistency.
+  params = {
+    signLanguage: "Q99628", // for videos : French Sign language
+    uiLanguage: "Q150", // for interface : French
+    historylimit: 6,
+    history: ["lapin", "crabe", "fraise", "canard"], // Some fun
+    wpintegration: true,
+    twospeed: true,
+    hinticon: true,
+    coloredwords: true,
+    choosepanels: "both", // issues/36
+  };
+
+// Get sign languages covered by Lingualibre
+// returns: [{ wdQid: "Q99628", labelNative: "langue des signes française"},{},...]
+async function getSignLanguagesWithVideos() {
+  var i,
+    signLanguage,
+    signLanguages = [], // ?? already define in global scopte
+    response = await $.post(sparqlEndpoints.lingualibre.url, {
+      format: "json",
+      query: sparqlSignLanguagesQuery,
+    });
+  // create signLanguages objects
+  for (i = 0; i < response.results.bindings.length; i++) {
+    var signLanguageRaw = response.results.bindings[i];
+    console.log("#149", signLanguageRaw);
+    signLanguage = {
+      wdQid: signLanguageRaw.id.value.split("/").pop(),
+      labelNative: signLanguageRaw.idLabel.value,
+    };
+    signLanguages[i] = signLanguage;
+  }
+  // TEMPORARY, WHEN ONLY LSF HAS VIDEOS
+  signLanguages = filterArrayBy(signLanguages, "wdQid", "Q99628");
+  console.log(signLanguages);
+
+  return signLanguages;
+}
+
+/* *************************************************************** */
+/* Settings management : memory, updates ************************* */
+// Save parameter and value in localStorage
+async function storeParam(name, value) {
+  // If value of type array, we make a copy of it to avoid dead references issues
+  if (Array.isArray(value)) {
+    value = Array.from(value); // copy
+  }
+  // else, create object { name: value }
+  console.log("HERE ! Selected option: { ", name + ": " + value + " }");
+  var tmp = {};
+  tmp[name] = value;
+  // reset params
+  params[name] = value;
+  return await chrome.storage.local.set(tmp);
+}
+
+// Get stored values from init hard coded `params` or from prefered local storage
+// Also synchronize both.
+async function getStoredParam(name) {
+  var tmp = await chrome.storage.local.get(name);
+  params[name] = tmp[name] || params[name] || null;
+  // If missing from local storage, then save init values in local storage
+  if (tmp.length == undefined) {
+    await storeParam(name, params[name]);
+  }
+  return params[name];
+}
+
+// Loading all vidéos of a given sign language. Format:
+// returns format: { word: { filename: url, speaker: name }, ... };
+async function getAllRecords(signLanguage) {
+  var i,
+    record,
+    word,
+    response,
+    records = {};
+
+  state = "loading";
+
+  response = await $.post(sparqlEndpoints.lingualibre.url, {
+    format: "json",
+    query: sparqlSignVideosQuery.replace("$(lang)", signLanguage),
+  });
+
+  for (i = 0; i < response.results.bindings.length; i++) {
+    record = response.results.bindings[i];
+    word = record.word.value.toLowerCase();
+    if (records.hasOwnProperty(word) === false) {
+      records[word] = [];
+    }
+    records[word].push({
+      filename: record.filename.value.replace("http://", "https://"),
+      speaker: record.speaker.value,
+    });
+  }
+
+  state = "ready";
+
+  console.log(Object.keys(records).length + " records loaded");
+  return records;
+}
+
+// Given language's Qid, reload list of available videos and records/words data
+async function changeLanguage(newLang) {
+  records = await getAllRecords(newLang);
+  await storeParam("signLanguage", newLang); // localStorage save
+}
+
+function normalize(selection) {
+  // this could do more
+  return selection.trim();
+}
+
+function wordToFiles(word) {
+  var fileData = records.hasOwnProperty(word)
+    ? records[word]
+    : records.hasOwnProperty(word.toLowerCase())
+    ? records[word.toLowerCase()]
+    : null;
+  return fileData;
+}
+
+/* *************************************************************** */
+/* Main ********************************************************** */
+async function main() {
+  state = "loading";
+
+  // Get local storage value if exist, else get default values
+  // promise.all
+  // await getStoredParam( 'history' );
+  // await getStoredParam( 'historylimit' );
+  // await getStoredParam( 'wpintegration' );
+  // await getStoredParam( 'twospeed' );
+  // storeParam( 'twospeed', params.twospeed ); //
+  // await getStoredParam( 'hinticon' );
+  // await getStoredParam( 'coloredwords' );
+  // await getStoredParam( 'choosepanels' );
+
+  signLanguage = await getStoredParam("signLanguage");
+  signLanguages = await getSignLanguagesWithVideos();
+  // uiLanguage = await getStoredParam( 'uiLanguage' );
+  // console.log("supportedUiLanguages",supportedUiLanguages)
+  // uiLanguages = supportedUiLanguages;
+  records = await getAllRecords(signLanguage);
+
+  state = "ready";
+}
+// main();
+chrome.runtime.onMessage.addListener(async (message, sender, sendResponse) => {
+  try {
+    await main(); // Call main function to populate data
+    console.log("Received message:", message);
+    if (message.type === "getBackground") {
+      sendResponse(message); // Send appropriate response
+    } else {
+      sendResponse("error received");
+    }
+  } catch (error) {
+    sendResponse("error occurred");
+  }
+});


### PR DESCRIPTION
This PR arose because of [issue#55](https://github.com/lingua-libre/SignIt/issues/55) (earlier closed with unmerged commits in [PR60](https://github.com/lingua-libre/SignIt/pull/60) due to its inability to work in FF, altho were later fixed by @hugolpz , but have introduced some other changes as well). Apparently upon unpacking the extension file it showed
```
Failed to load extension
File
~\Downloads\SignIt\SignIt-master
Error
'content_security_policy.extension_pages': Insecure CSP value "https://commons.wikimedia.org" in directive 'object-src'.
Could not load manifest.
```
The issue could have been resolved by simply removing `object-src 'self' https://commons.wikimedia.org;` from extension pages but I not only removed it but also updated it as per the syntax of manifest V3 which changed `extension_pages` to a dictionary and introduced the `sandbox` key. Now upon unpacking it won't show CSP related issues in chrome dev mode . In FF it will show warning about `sandbox` but nothing more than that. .Referenced [Click here to see changes](https://github.com/lingua-libre/SignIt/pull/63/commits/2e8245901bb9c5836ec62aee164255f791d400c5)
Also with the removal of insecure CSP we wont be needing the CSP header bypass logic as well, not for chrome at the very least inside `sw.js` .
### Additional Info on Cross browser background scripts

Regarding background scripts , apparently chrome and FF have different entrypoints , FF uses background pages by using `"background":{"scritps":[background.js]}`, but chrome no longer accepts that and has a different entry point , something like `"background":{"service_worker" : "background.js"}`. So in order to make cross browser background-scripts we can add both entrypoints to make it work. We can further add guards to our manifest for users with older versions of chrome/FF to make them get these updates( mentioned [here](https://www.youtube.com/watch?v=ExTb4UoGTss) skip to 23:33 to see this snippet). 

```
"browser_specific_settings": {
"gecko": {
"id": "script-on-click@example",
"strict_min_version": "121.0a1"
},
"gecko android": {
"strict min version": "121.0a1"
},
"minimum_chrome_version": "121"
},

```

Although I doubt that'll unlikely be the case , not to mention it shows warning in chrome as deeming `"browser_specific_settings"` as unidentified.

### No need for polyfills : [Click here to see changes](https://github.com/lingua-libre/SignIt/pull/63/commits/c584f1303a43fdb5ed652bf0f035afdb1da2bdc8)

 In the past (manifest V2), promises worked in Firefox but not in Chrome. So, we had to use polyfills. Now (V3), Chrome APIs support promises, removing the need for polyfills.

### Typechecking browser in popup and introduction of sw.js(service-worker) : [Click here to see changes](https://github.com/lingua-libre/SignIt/pull/63/commits/1e1e8dfbffe24d902ce6b5b7f45ddde9af79f143)

When working with service_worker, we need to pass messages in order to communicate with our content scripts . . . which could be solely achieved by using chrome apis, due to which I changed the way we used `var browser` earlier, so that we can interchange with chrome and FF runtime.

Making `sw.js` seperately because , when I tried runnig the same script in `background.js` , service worker failed to register and exited with code 15,might change later my understanding is better, but for now we can see an active service worker . . . Earlier it also used to show 

 `error : background page not found`

That is not so the case any longer . . . a background page is certainly recognised.

### Changes dated 31st March

Well they are descriptive enough by their commit message headings , also I have provided in depth explanation of the changes I have made inside the codebase through comments, there I have solved issues related to seeing modal, importing banana module inside `sw,js` as well as exporting it to `popup.js` while maintaining its functionality like earlier, but  would still like to mention some points where code is still broken and responds weirdly.

**Issue 1** : Modal doesn't appear right away when accessed through `contextMenu` or `hintIcon`

**Reproduce** : click on Lingua Libre SignIt in `contextMenu` , then you might see hint icon , click on it and then your modal might appear. . . .still needs to be worked upon but something's better than nothing.

As far as the state and other variables are concerned , they need to persisted in `chrome.storage.local` but for now I've sent them through an object whenever `getBackground` message is passed , similar has to be done for all the functions that are being accessed in content scripts, will work on that later when I have figured it out .

**Issue 2** : The fetch API post requests won't work , I get `status code 405 : Method not allowed`, despite being an ideal approach to replace jQuery which is incompatible with service_worker.

**Approach** : We can leverage the power of offscreen API and use the jQuery `$.post` requests there , and can make it communicate with `sw.js` by passing messages like we normally do with other content scripts, haven't implemented yet but should work just fine.

Whole popup wont be visible but something like this should be there

![Screenshot (39)](https://github.com/lingua-libre/SignIt/assets/123084434/f1ad28f1-8850-4ca8-84d4-428f2b91098a)

**Again apologies for the long PR , should've raised them on a daily basis**