### PR TITLE
Refactor i18n Localization and Background Page Fetch

### DIFF
--- a/SignItCoreContent.js
+++ b/SignItCoreContent.js
@@ -1,20 +1,25 @@
 // const { default: backgroundPage } = require("./background-script"); // to try
 
-var banana;
+var banana,resArr;
 (async()=>{
-  const sourceMap = new Map(
-    await chrome.runtime.sendMessage({ command: "getBanana" })
-  );
-  banana = { i18n: (msg) => sourceMap.get("fr")[msg] };
+  resArr = await chrome.runtime.sendMessage({ command: "getBanana" });
+  console.log(resArr);
+  const sourceMap = new Map(resArr[0]);
+  banana = { i18n: (msg,locale) => sourceMap.get(locale)[msg] };
 })();
 
-var SignItCoreContent = function () {
-  console.log("Passed trough ! :", banana)
-  console.log("SignItCoreContent.js");
-  // console.log("banana",banana) // -> Uncaught (in promise) Error: banana is not defined
-  // background.js not accessible natively
-  // HOW TO IMPORT background.js and its banana i18n ?
-  // See issue #21
+var SignItCoreContent = function (locale) {
+  // in case of firefox 
+  if ((locale.messageStore.sourceMap) instanceof Map) { 
+    const sourceMap = new Map(locale.messageStore.sourceMap);
+    locale = locale.locale;
+    banana = { i18n: (msg,locale) => sourceMap.get(locale)[msg] };
+  }
+  else{ // in case of chrome
+    locale = resArr[1];
+  }
+  console.log("Passed trough ! :", locale);
+  console.log("SignItCoreContent.js",banana );
   this.$container = $(`
 		<div class="signit-popup-container">
 			<h1></h1>
@@ -22,8 +27,8 @@ var SignItCoreContent = function () {
         <div class="signit-panel-videos">
           <div class="signit-panel-videos signit-novideo">
             <h2>Media:
-            ${ banana.i18n("si-overlay-coreContent-left-title") }</h2>
-            Pas de video disponible.${ banana.i18n("si-overlay-coreContent-left-novideo") }<br><br>
+            ${ banana.i18n("si-overlay-coreContent-left-title",locale) }</h2>
+            Pas de video disponible.${ banana.i18n("si-overlay-coreContent-left-novideo",locale) }<br><br>
           </div>
           <div class="signit-panel-videos signit-video"></div>
         </div>
@@ -31,13 +36,13 @@ var SignItCoreContent = function () {
         <div class="signit-panel-definition">
           <div class="signit-panel-definition signit-definition">
             <h2>Definition:
-            ${ banana.i18n("si-overlay-coreContent-right-title") }</h2>
+            ${ banana.i18n("si-overlay-coreContent-right-title",locale) }</h2>
             <button id="video_toggle" >video?</button>
             <div class="signit-definition-text"></div>
             <div class="signit-definition-source">
               <a href="https://fr
-          ${ banana.i18n("si-overlay-coreContent-right-wikt-iso") }.wiktionary.org">voir sur Wiktionaire
-          ${ banana.i18n("si-overlay-coreContent-right-wikt-pointer") }</a>
+          ${ banana.i18n("si-overlay-coreContent-right-wikt-iso",locale) }.wiktionary.org">
+          ${ banana.i18n("si-overlay-coreContent-right-wikt-pointer",locale) }</a>
             </div>
           </div>
           <div class="signit-panel-definition signit-loading">
@@ -46,7 +51,7 @@ var SignItCoreContent = function () {
             )}" width="40" height="40">
           </div>
           <div class="signit-panel-definition signit-error">Pas définition disponible.
-          ${ banana.i18n("si-overlay-coreContent-right-error") }</div>
+          ${ banana.i18n("si-overlay-coreContent-right-error",locale) }</div>
         </div>
 			</div>
 		</div>

--- a/content_scripts/signit.css
+++ b/content_scripts/signit.css
@@ -194,16 +194,16 @@
 
 /* *************************************************************** */
 /* Icons ********************************************************* */
-.oo-ui-icon-next {
-  background-image: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMCIgaGVpZ2h0PSIyMCIgdmlld0JveD0iMCAwIDIwIDIwIj4KCTx0aXRsZT4KCQluZXh0Cgk8L3RpdGxlPgoJPHBhdGggZD0iTTcgMUw1LjYgMi41IDEzIDEwbC03LjQgNy41TDcgMTlsOS05eiIvPgo8L3N2Zz4K");
+oo-ui-icon-next {
+	background-image: url( '../icons/arrow-right-solid.svg' );
 }
 
 .oo-ui-icon-previous {
-  background-image: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjIwIiBoZWlnaHQ9IjIwIiB2aWV3Qm94PSIwIDAgMjAgMjAiPjx0aXRsZT5wcmV2aW91czwvdGl0bGU+PHBhdGggZD0iTTQgMTBsOSA5IDEuNC0xLjVMNyAxMGw3LjQtNy41TDEzIDF6Ii8+PC9zdmc+");
+	background-image: url( '../icons/arrow-left-solid.svg' );
 }
 
 .oo-ui-icon-search {
-  background-image: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMCIgaGVpZ2h0PSIyMCIgdmlld0JveD0iMCAwIDIwIDIwIj4KCTx0aXRsZT4KCQlzZWFyY2gKCTwvdGl0bGU+Cgk8cGF0aCBkPSJNMTkgMTdsLTUuMTUtNS4xNWE3IDcgMCAxIDAtMiAyTDE3IDE5ek0zLjUgOEE0LjUgNC41IDAgMSAxIDggMTIuNSA0LjUgNC41IDAgMCAxIDMuNSA4eiIvPgo8L3N2Zz4K");
+	background-image: url( '../icons/magnifying-glass-solid.svg' );
 }
 
 /* *************************************************************** */


### PR DESCRIPTION
**Description:**
This Pull Request addresses the following changes:
1. **Fix:** Resolved an issue with i18n localization in SignItCoreContent.js to ensure compatibility with both Chrome and Firefox. The issue was referenced earlier at [#19](https://github.com/lingua-libre/SignIt/issues/19) where relevant challenges faced are mentioned. While I did try passing banana as a parameter , and its values are certainly passed , the i18n functionality isn't imported...in my commit earlier emphasized on the same but things only worked in Chrome...now they do in FF as well
2. **Update:** Updated the SVG icon URLs for previous, next, and search in popup.css for improved UI aesthetics.
3. **Refactor:** Streamlined the code to fetch the background page efficiently for better performance.

**Changes:**
- Refactored code in SignItCoreContent.js for i18n localization fix.
- Updated SVG icon URLs in popup.css for better icon display.
- Optimized code for background page fetching for enhanced efficiency.

**Commits:**
1. af51c9a - Fix issue with i18n localization in SignItCoreContent.js
2. 92a23e1 - Update SVG icon URLs in popup.css
3. 46339be - Refactor code to fetch the background page efficiently