### PR TITLE
Version Bump (1.0.21 -> 1.0.22) and sendResponse Update

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 3,
 	"name": "Lingua Libre SignIt",
-	"version": "1.0.21",
+	"version": "1.0.22",
 	"author": "Antoine '0x010C' Lamielle, Hugo Lopez",
 	"description": "SignIt translate a selected word into Sign Language videos.",
 	"homepage_url": "https://lingualibre.org",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sign-it",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "description": "SignIt translate a selected word into Sign Language videos",
   "main": "background-script.js",
   "dependencies": {

--- a/sw.js
+++ b/sw.js
@@ -777,13 +777,9 @@ async function setState(value) {
       message.command === "getBanana"
     ) {
       console.log("bg>signit.getfilesB");
-	// var locale = await getStoredParam( 'uiLanguage' )
-	// loadI18nLocalization(locale);
-	//   return banana;
-    
-  // What this does is it accesses the messageStore inside banana amd spreads the sourecMap
-  // which is an instanceof Map thereby converting it into an array. This is later recreated inside popup
-      sendResponse([...banana.messageStore.sourceMap]);
+      // What this does is it accesses the messageStore inside banana amd spreads the sourecMap
+      // which is an instanceof Map thereby converting it into an array. This is later recreated inside popup
+      sendResponse([[...banana.messageStore.sourceMap], banana.locale]);
     }
 
     // Start modal


### PR DESCRIPTION
**Description**
 This PR addresses the following changes:-

1.  **Refactor** :Updated the `sendResponse` to send banana source map as well as locale
2. **Update** : Changed version from `1.0.21` to `1.0.22` in `manifest.json` as well as `package.json`

**Commits:**

1. [fbca3ff](fbca3ff60889753176244b1f4f0019d3726200c5) - Changed the bump version in `manifest.json` and `package.json`
2. [109498](109498d4a03f3ae354b35cb925a87e1889cd0e94) - Updated the `sendResponse` function