### PR TITLE
Refactor `SignItCoreContent` for browser compatibility & modal init fix

### DIFF
--- a/SignItCoreContent.js
+++ b/SignItCoreContent.js
@@ -1,23 +1,6 @@
-// const { default: backgroundPage } = require("./background-script"); // to try
-
-var banana,resArr;
-(async()=>{
-  resArr = await chrome.runtime.sendMessage({ command: "getBanana" });
-  console.log(resArr);
-  const sourceMap = new Map(resArr[0]);
+var SignItCoreContent = function (locale,map) {
+  const sourceMap = new Map(map);
   banana = { i18n: (msg,locale) => sourceMap.get(locale)[msg] };
-})();
-
-var SignItCoreContent = function (locale) {
-  // in case of firefox 
-  if ((locale.messageStore.sourceMap) instanceof Map) { 
-    const sourceMap = new Map(locale.messageStore.sourceMap);
-    locale = locale.locale;
-    banana = { i18n: (msg,locale) => sourceMap.get(locale)[msg] };
-  }
-  else{ // in case of chrome
-    locale = resArr[1];
-  }
   console.log("Passed trough ! :", locale);
   console.log("SignItCoreContent.js",banana );
   this.$container = $(`

--- a/background-script.js
+++ b/background-script.js
@@ -402,7 +402,7 @@ browser.runtime.onMessage.addListener( async function ( message ) {
     return;
   } else if (message.command === "normalizeWordAndReturnFiles") {
     const word = normalize(message.argument);
-    const files = wordToFiles(w);
+    const files = wordToFiles(word);
     return [word, files];
   }
   else if (message.command === "changeUiLanguage") {

--- a/background-script.js
+++ b/background-script.js
@@ -165,6 +165,7 @@ async function loadI18nLocalization( uiLanguageQid ) {
 	// Declare localisation
 	banana.setLocale(locale); // Change to new locale
 	storeParam('bananaInStore',banana)
+    storeParam("sourceMap", Array.from(banana.messageStore.sourceMap));
 	
 	state = 'ready';
 
@@ -272,7 +273,15 @@ function normalize( selection ) { // this could do more
 
 // Check a string with multiple words and return the word whose record is available
 function getAvailableWord( word ) {
-	const wordArray = word.split(" ");
+
+	// while this makes for an ungly regex , I couldn't think of anything else. 
+	// Using metacharcters like /W or /w meant removing accented letters as well, which would have broken 
+	// many french words . . .so I retorted to this;
+	
+	const regex = /[!"#$%&()*+,-./:;<=>?@[\\\]^_{|}~]/;
+	const stringWithoutSpecialChars = word.replace(regex,"");
+	const wordArray = stringWithoutSpecialChars.split(" ");
+	console.log(wordArray);
 	for ( let newWord of wordArray ) {
 		if( records.hasOwnProperty(newWord.toLowerCase()) ){
 			return newWord;
@@ -389,13 +398,17 @@ browser.runtime.onMessage.addListener( async function ( message ) {
 	// inside both chrome and firefox
 	
 	if (message.command === "checkActiveTabInjections") {
-    await checkActiveTabInjections(message.currentTabId);
+    await checkActiveTabInjections(message.argument);
     return;
   } else if (message.command === "normalizeWordAndReturnFiles") {
-    const w = normalize(message.text);
-    const f = wordToFiles(w);
-    return [w, f];
+    const word = normalize(message.argument);
+    const files = wordToFiles(w);
+    return [word, files];
   }
+  else if (message.command === "changeUiLanguage") {
+	await changeUiLanguage(message.argument);
+	return;
+}
 	message = normalizeMessage(message);
 
 	// When message 'signit.getfiles' is heard, returns relevant extract of records[]
@@ -420,10 +433,6 @@ browser.runtime.onMessage.addListener( async function ( message ) {
 		storeParam([...message.arguments]);
 		return;
 	}
-	// else if (message.command === "changeUiLanguage") {
-	// 	await changeUiLanguage(message.newLanguage);
-	// 	return;
-	// }
 });
 
 /* *************************************************************** */

--- a/content_scripts/signit.js
+++ b/content_scripts/signit.js
@@ -153,9 +153,10 @@
 		// Banana test, search `bananaInStore` in files for more
 		console.log("before")
 		var BetterBanana = await browser.storage.local.get( 'bananaInStore' );
-		console.log("after: BetterBanana = ", BetterBanana.bananaInStore)
+		var messageStore = await browser.storage.local.get( 'sourceMap' ); 
+		console.log("after: BetterBanana = ", BetterBanana.bananaInStore.locale,messageStore.sourceMap)
 
-		content = new SignItCoreContent(BetterBanana.bananaInStore);
+		content = new SignItCoreContent(BetterBanana.bananaInStore.locale,messageStore.sourceMap);
 
 		// Setup an absolute-positionned $anchorModal we can programatically move
 		// to be able to point exactly some coords with our popup later
@@ -217,7 +218,9 @@
 
 		// Modal generation or refresh
 		if ( message.command === 'signit.sign' || message.command === 'signit.hinticon') {
-			if ( popup === undefined ) { initModalUI(); }
+			// initialising modal everytime not only when popup is undefined ,
+			// by this we won't have to reload the web page everytime 
+			initModalUI(); 
 			var coords = getSelectionCoords();
 			repositionElement($anchorModal,coords);
 			resizeElement($anchorModal,coords);

--- a/sw.js
+++ b/sw.js
@@ -439,6 +439,7 @@ async function setState(value) {
     // Declare localisation
     banana.setLocale(locale); // Change to new locale
     storeParam("bananaInStore", banana);
+    storeParam("sourceMap", Array.from(banana.messageStore.sourceMap));
 
     // state = "ready";
     state = await setState("ready");
@@ -742,9 +743,9 @@ async function setState(value) {
     // the message which renders the test undefined
 
     if (message.command === "normalizeWordAndReturnFiles") {
-      const w  = normalize(message.text);
-      const f  = wordToFiles(w);
-      sendResponse([w,f]);
+      const word  = normalize(message.argument);
+      const files  = wordToFiles(word);
+      sendResponse([word,files]);
     }
     message = normalizeMessage(message);
 
@@ -773,13 +774,13 @@ async function setState(value) {
       callModal(message);
     } 
     else if (message.command === "checkActiveTabInjections") {
-      checkActiveTabInjections(message.currentTabId);
+      checkActiveTabInjections(message.argument);
     }
     else if (message.command === "storeParam") {
-      storeParam([...message.arguments]);
+      storeParam([...message.argument]);
     }
     else if (message.command === "changeUiLanguage") {
-      await changeUiLanguage(message.newLanguage);
+      await changeUiLanguage(message.argument);
     }
   });
 


### PR DESCRIPTION
**Changes**

1. [b9cf4f](b9cf4fb351a0595403a1a8f94c10ba50d9c4bc38) - Made a function to pass messages in order to adhere to DRY principle. Allows reusability while not cluttering the codebase and optimizes the message passing process.
2. [6505f6](6505f6027a716cd2317a1728edf61a6e67f87310) - Refactored the way `SignItCoreContent.js` received `banana` such that it is universal to both Chrome and FF.
3. [557293](55729349cff18dbc1757d88aa51402d6c6de13ff)  - Initialized modal every time when `signit.hintIcon` message was passed rather than calling it only when popup was undefined.

**Description**

- I'll start with the 2nd change since first change is self explanatory.

  **Issue:** Earlier I was type checking the browser using conditionals for the desired changes and that was also because , when arguments were passed in the `SignItCoreContent()` constructor function , it received `banana`'s `sourceMap` as an instance of `Map` in Firefox and as `Object` in Chrome. 
  
  While this worked it passed unnecessary messages in `background-script.js` and made for an undesirable code overall.
  
  **Solution:** I stored the `sourceMap` inside `browser.storage.local` and later passed it as argument whenever constructor function was in use. This is compatible with both Chrome and Firefox and I think it overall makes for a better code.

- 3rd change is a potential fix for challenges faced after #71 

  **Issue:** After passing messages from `popup.js` to both `sw.js` and `background-script,js` to execute functions (because we cant use `backgroundPage` as API namespace in MV3 unlike FF), the way UI language was being updated is buggy.
  
  - Firefox - In FF Popup UI updates immediately but for the changes to reflect in Modal whole web page has to be reloaded
  - Chrome - In Chrome Popup UI updates after it is toggled OFF then ON again , and same has to be done as FF to see changes in modal
 
  **Solution:** Whenever `signit.hintIcon` is executed (modal is activated) `initModalUI` function is called every time unlike earlier when it is called only when `popup === undefined`. While this is a temporary fix since things were somehow working fine before previous PR. By doing this at least page does not need to be reloaded.