### PR TITLE
Introduce internationalization inside `SignItVideosGallery.js`

### DIFF
--- a/SignItCoreContent.js
+++ b/SignItCoreContent.js
@@ -1,6 +1,6 @@
 var SignItCoreContent = function (locale,mapi18n) {
   const sourceMap = new Map(mapi18n);
-  banana = { i18n: (msg,locale) => sourceMap.get(locale)[msg] };
+  banana = { i18n: (msg) => sourceMap.get(locale)[msg] };
   console.log("Passed trough ! :", locale);
   console.log("SignItCoreContent.js",banana );
   this.$container = $(`
@@ -10,8 +10,8 @@ var SignItCoreContent = function (locale,mapi18n) {
         <div class="signit-panel-videos">
           <div class="signit-panel-videos signit-novideo">
             <h2>
-            ${ banana.i18n("si-panel-videos-title",locale) }</h2>
-            ${ banana.i18n("si-panel-videos-empty",locale) }<br><br>
+            ${ banana.i18n("si-panel-videos-title") }</h2>
+            ${ banana.i18n("si-panel-videos-empty") }<br><br>
           </div>
           <div class="signit-panel-videos signit-video"></div>
         </div>
@@ -19,11 +19,11 @@ var SignItCoreContent = function (locale,mapi18n) {
         <div class="signit-panel-definitions">
           <div class="signit-panel-definitions signit-definitions">
             <h2>
-            ${ banana.i18n("si-panel-definitions-title",locale) }</h2>
+            ${ banana.i18n("si-panel-definitions-title") }</h2>
             <div class="signit-definitions-text"></div>
             <div class="signit-definitions-source">
-              <a href="https://${ banana.i18n("si-panel-definitions-wikt-iso",locale) }.wiktionary.org">
-          ${ banana.i18n("si-panel-definitions-wikt-pointer",locale) }</a>
+              <a href="https://${ banana.i18n("si-panel-definitions-wikt-iso") }.wiktionary.org">
+          ${ banana.i18n("si-panel-definitions-wikt-pointer") }</a>
             </div>
           </div>
           <div class="signit-panel-definitions signit-loading">
@@ -32,7 +32,7 @@ var SignItCoreContent = function (locale,mapi18n) {
             )}" width="40" height="40">
           </div>
           <div class="signit-panel-definitions signit-error">
-          ${ banana.i18n("si-panel-definitions-empty",locale) }</div>
+          ${ banana.i18n("si-panel-definitions-empty") }</div>
         </div>
 			</div>
 		</div>
@@ -41,7 +41,7 @@ var SignItCoreContent = function (locale,mapi18n) {
     // Button contribute
     var optionsContribute = {
       flags: ["primary", "progressive"],
-      label: banana.i18n("si-panel-videos-contribute-label",locale) ,
+      label: banana.i18n("si-panel-videos-contribute-label") ,
       href: "https://lingualibre.org/wiki/Special:RecordWizard",
     };
     this.contributeButton = new OO.ui.ButtonWidget(optionsContribute);
@@ -128,7 +128,7 @@ var SignItCoreContent = function (locale,mapi18n) {
     );
     $wiktSection = content
       .find(
-        "#Français" /* banana.i18n("si-panel-definitions-wikt-section-id",locale) ? banana.i18n("si-panel-definitions-wikt-section-id",locale) : ''*/
+        "#Français" /* banana.i18n("si-panel-definitions-wikt-section-id") ? banana.i18n("si-panel-definitions-wikt-section-id",locale) : ''*/
       )
       .parent()
       .next();

--- a/SignItVideosGallery.js
+++ b/SignItVideosGallery.js
@@ -16,7 +16,22 @@ var SignItVideosGallery = function ( container ) {
 	}.bind( this ) );
 };
 
-SignItVideosGallery.prototype.refresh = function ( files ) {
+SignItVideosGallery.prototype.refresh = async function ( files ) {
+	var BetterBanana = await browser.storage.local.get( 'bananaInStore' );
+	var messageStore = await chrome.storage.local.get( 'sourceMap' ); 
+	var sourceMap = new Map(messageStore.sourceMap);
+	var locale = BetterBanana.bananaInStore.locale;
+	console.log(sourceMap);
+	var banana = {
+    i18n: (msg, url, speaker,index, total) => {
+		let  string  = sourceMap.get(locale)[msg];
+		let Speaker = `<a href=${url}>${speaker}</a>`;
+		let stringWithSpeaker = string.replace("{{link|$1|$2}}",Speaker);
+		let stringWithIndex = stringWithSpeaker.replace("$3",index);
+		let stringWithTotal = stringWithIndex.replace("$4",total);
+      return stringWithTotal;
+    },
+  };
 	console.log("#20 files ",files )
 	console.log("Expected: [{ filename: url, speaker: ... },...]")	
 	var i;
@@ -27,17 +42,17 @@ SignItVideosGallery.prototype.refresh = function ( files ) {
 	this.currentIndex = 0;
 
 	for ( i = 0; i < files.length; i++ ) {
-		// filename = files[ i ].filename,
-		// url = `https://commons.wikimedia.org/wiki/File:${ filename.split( '/' ).pop()}`,
-		// speaker = files[ i ].speaker,
-		// total = files.length;
-		// ${ banana.i18n("si-panel-videos-gallery-attribution", url, speaker, i+1, total) }
+		filename = files[ i ].filename,
+		url = `https://commons.wikimedia.org/wiki/File:${ filename.split( '/' ).pop()}`,
+		speaker = files[ i ].speaker,
+		total = files.length;
 		this.$videos.push( $( `
 			<div style="display: none;">
 				<video controls="" muted="" preload="auto" src="${ files[ i ].filename }" width="250" class=""></video>
-				par <a href="https://commons.wikimedia.org/wiki/File:${ files[ i ].filename.split( '/' ).pop() }">${ files[ i ].speaker }</a> – Vidéo ${ i + 1 } sur ${ files.length }
+				${banana.i18n("si-panel-videos-gallery-attribution", url, speaker, i+1, total)}
 			</div>
 		` ) );
+
 		this.$videoContainer.append( this.$videos[ i ] );
 	}
 	this.switchVideo( 0 );

--- a/SignItVideosGallery.js
+++ b/SignItVideosGallery.js
@@ -21,15 +21,18 @@ SignItVideosGallery.prototype.refresh = async function ( files ) {
 	var messageStore = await chrome.storage.local.get( 'sourceMap' ); 
 	var sourceMap = new Map(messageStore.sourceMap);
 	var locale = BetterBanana.bananaInStore.locale;
-	console.log(sourceMap);
 	var banana = {
     i18n: (msg, url, speaker,index, total) => {
-		let  string  = sourceMap.get(locale)[msg];
-		let Speaker = `<a href=${url}>${speaker}</a>`;
-		let stringWithSpeaker = string.replace("{{link|$1|$2}}",Speaker);
-		let stringWithIndex = stringWithSpeaker.replace("$3",index);
-		let stringWithTotal = stringWithIndex.replace("$4",total);
-      return stringWithTotal;
+		let string = sourceMap.get(locale)[msg];
+		let Speaker = `<a href=${url}>${speaker} </a>`;
+		let patterns = ["{{link|$1|$2}}", "$3", "$4"];
+		let replacements = [Speaker, index, total];
+
+		patterns.forEach((pattern,index)=>{
+			string = string.replace(pattern, replacements[index]);
+		})
+
+		return string;
     },
   };
 	console.log("#20 files ",files )


### PR DESCRIPTION
**Changes**

1. [3ea398](3ea398906b90007e86c09dc8e1a87a042ea5139e) - I directly passed the fetched locale inside my `i18n` function instead of passing it as an argument every time that function was called.
2. [d8c8e6](d8c8e6035cd72fb112d16f471c1c6fe8f1f0a096) - This commit is an improvisation of [96fa35](96fa351398bceee52470761be8166a17aba0fbb8). Overall it modifies the `i18n` function to fetch the message of respective locale and then return it while inserting the links and other variables inside it.

**NOTE:** Some unexpected changes are bound to be seen. 

- First of all , the change will only be reflected in FF since videos don't work in Chrome right now.
- Second, the locale of popup UI and `VideoGallery` change together unlike in core content , so you might see 2 languages in the modal upon changing the language....not a new issue , old recent persistent one , working on that as well. 