### PR TITLE
Testing `browser.i18n` API

### DIFF
--- a/SignItCoreContent.js
+++ b/SignItCoreContent.js
@@ -3,6 +3,8 @@ var SignItCoreContent = function (locale,mapi18n) {
   banana = { i18n: (msg) => sourceMap.get(locale)[msg] };
   console.log("Passed trough ! :", locale);
   console.log("SignItCoreContent.js",banana );
+  // let hlwa = browser.i18n.getMessage("si-panel-videos-title"); 
+  // console.log("hlwa = ",hlwa); 
   this.$container = $(`
 		<div class="signit-modal-container">
 			<h1></h1>
@@ -10,8 +12,8 @@ var SignItCoreContent = function (locale,mapi18n) {
         <div class="signit-panel-videos">
           <div class="signit-panel-videos signit-novideo">
             <h2>
-            ${ banana.i18n("si-panel-videos-title") }</h2>
-            ${ banana.i18n("si-panel-videos-empty") }<br><br>
+            ${ browser.i18n.getMessage("si_panel_videos_title") }</h2>
+            ${ browser.i18n.getMessage("si_panel_videos_empty") }<br><br>
           </div>
           <div class="signit-panel-videos signit-video"></div>
         </div>
@@ -19,11 +21,11 @@ var SignItCoreContent = function (locale,mapi18n) {
         <div class="signit-panel-definitions">
           <div class="signit-panel-definitions signit-definitions">
             <h2>
-            ${ banana.i18n("si-panel-definitions-title") }</h2>
+            ${ browser.i18n.getMessage("si_panel_definitions_title") }</h2>
             <div class="signit-definitions-text"></div>
             <div class="signit-definitions-source">
-              <a href="https://${ banana.i18n("si-panel-definitions-wikt-iso") }.wiktionary.org">
-          ${ banana.i18n("si-panel-definitions-wikt-pointer") }</a>
+              <a href="https://${ browser.i18n.getMessage("si_panel_definitions_wikt_iso") }.wiktionary.org">
+          ${ browser.i18n.getMessage("si_panel_definitions_wikt_pointer") }</a>
             </div>
           </div>
           <div class="signit-panel-definitions signit-loading">
@@ -32,7 +34,7 @@ var SignItCoreContent = function (locale,mapi18n) {
             )}" width="40" height="40">
           </div>
           <div class="signit-panel-definitions signit-error">
-          ${ banana.i18n("si-panel-definitions-empty") }</div>
+          ${ browser.i18n.getMessage("si_panel_definitions_empty") }</div>
         </div>
 			</div>
 		</div>
@@ -41,7 +43,7 @@ var SignItCoreContent = function (locale,mapi18n) {
     // Button contribute
     var optionsContribute = {
       flags: ["primary", "progressive"],
-      label: banana.i18n("si-panel-videos-contribute-label") ,
+      label: browser.i18n.getMessage("si_panel_videos_contribute_label") ,
       href: "https://lingualibre.org/wiki/Special:RecordWizard",
     };
     this.contributeButton = new OO.ui.ButtonWidget(optionsContribute);

--- a/SignItVideosGallery.js
+++ b/SignItVideosGallery.js
@@ -52,7 +52,7 @@ SignItVideosGallery.prototype.refresh = async function ( files ) {
 		this.$videos.push( $( `
 			<div style="display: none;">
 				<video controls="" muted="" preload="auto" src="${ files[ i ].filename }" width="250" class=""></video>
-				${banana.i18n("si-panel-videos-gallery-attribution", url, speaker, i+1, total)}
+				${browser.i18n.getMessage("si_panel_videos_gallery_attribution",[ url, speaker, i+1, total])}
 			</div>
 		` ) );
 

--- a/_locales/anp/messages.json
+++ b/_locales/anp/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "<a href='$1'>$2</a> द्वारा – $4 मँ सँ $3 नंबरिया वीडियो",
+    "message": "<a href='$1' target='_blank'>$2</a> द्वारा – $4 मँ सँ $3 नंबरिया वीडियो",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/az/messages.json
+++ b/_locales/az/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "<a href='$1'>$2</a> – Video $3/$4",
+    "message": "<a href='$1' target='_blank'>$2</a> – Video $3/$4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/blk/messages.json
+++ b/_locales/blk/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "<a href='$1'>$2</a>တွမ်ႏ – ဗီဒီယို $3 ယို $4",
+    "message": "<a href='$1' target='_blank'>$2</a>တွမ်ႏ – ဗီဒီယို $3 ယို $4",
     "description": ""
   },
   "si_panel_videos_contribute_label": {

--- a/_locales/bn/messages.json
+++ b/_locales/bn/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "<a href='$1'>$2</a> দ্বারা – $4 এর মধ্যে $3 নং ভিডিও",
+    "message": "<a href='$1' target='_blank'>$2</a> দ্বারা – $4 এর মধ্যে $3 নং ভিডিও",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/br/messages.json
+++ b/_locales/br/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "gant <a href='$1'>$2</a> – $3 eus $4 video",
+    "message": "gant <a href='$1' target='_blank'>$2</a> – $3 eus $4 video",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/ce/messages.json
+++ b/_locales/ce/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "авторалла: <a href='$1'>$2</a> – $3 видео $4 чохь",
+    "message": "авторалла: <a href='$1' target='_blank'>$2</a> – $3 видео $4 чохь",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "von <a href='$1'>$2</a> – Video $3 von $4",
+    "message": "von <a href='$1' target='_blank'>$2</a> – Video $3 von $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/diq/messages.json
+++ b/_locales/diq/messages.json
@@ -8,7 +8,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "Be <a href='$1'>$2</a> ra – Video $3 yê $4",
+    "message": "Be <a href='$1' target='_blank'>$2</a> ra – Video $3 yê $4",
     "description": ""
   },
   "si_panel_definitions_title": {

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "by <a href='$1'>$2</a> – Video $3 of $4",
+    "message": "by <a href='$1' target='_blank'>$2</a> – Video $3 of $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "por <a href='$1'>$2</a> – Video $3 de $4",
+    "message": "por <a href='$1' target='_blank'>$2</a> – Video $3 de $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/fa/messages.json
+++ b/_locales/fa/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "توسط <a href='$1'>$2</a> – ویدئو $3 از میان $4",
+    "message": "توسط <a href='$1' target='_blank'>$2</a> – ویدئو $3 از میان $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/fi/messages.json
+++ b/_locales/fi/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "tekijä: <a href='$1'>$2</a> – Video $3 / $4",
+    "message": "tekijä: <a href='$1' target='_blank'>$2</a> – Video $3 / $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "par <a href='$1'>$2</a> – Vidéo $3 sur $4",
+    "message": "par <a href='$1' target='_blank'>$2</a> – Vidéo $3 sur $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/gl/messages.json
+++ b/_locales/gl/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "por <a href='$1'>$2</a> – Vídeo $3 de $4",
+    "message": "por <a href='$1' target='_blank'>$2</a> – Vídeo $3 de $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/he/messages.json
+++ b/_locales/he/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "מאת <a href='$1'>$2</a> – סרט $3 מתוך $4",
+    "message": "מאת <a href='$1' target='_blank'>$2</a> – סרט $3 מתוך $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/hi/messages.json
+++ b/_locales/hi/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "<a href='$1'>$2</a> द्वारा – $4 में से $3 नंबरी वीडियो",
+    "message": "<a href='$1' target='_blank'>$2</a> द्वारा – $4 में से $3 नंबरी वीडियो",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/hy/messages.json
+++ b/_locales/hy/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "հեղինակ՝ <a href='$1'>$2</a> – տեսանյութ $3 $4-ից",
+    "message": "հեղինակ՝ <a href='$1' target='_blank'>$2</a> – տեսանյութ $3 $4-ից",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/ia/messages.json
+++ b/_locales/ia/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "per <a href='$1'>$2</a> – Video $3 de $4",
+    "message": "per <a href='$1' target='_blank'>$2</a> – Video $3 de $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/id/messages.json
+++ b/_locales/id/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "oleh <a href='$1'>$2</a> – Video $3 dari $4",
+    "message": "oleh <a href='$1' target='_blank'>$2</a> – Video $3 dari $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "di <a href='$1'>$2</a> - Video $3 di $4",
+    "message": "di <a href='$1' target='_blank'>$2</a> - Video $3 di $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "<a href='$1'>$2</a>に帰属  – 動画 $4件中の$3件目",
+    "message": "<a href='$1' target='_blank'>$2</a>に帰属  – 動画 $4件中の$3件目",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/kk-cyrl/messages.json
+++ b/_locales/kk-cyrl/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "ауторы: <a href='$1'>$2</a> — $3/$4 видео",
+    "message": "ауторы: <a href='$1' target='_blank'>$2</a> — $3/$4 видео",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "만든이: <a href='$1'>$2</a> – 동영상 $3 / $4",
+    "message": "만든이: <a href='$1' target='_blank'>$2</a> – 동영상 $3 / $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/krc/messages.json
+++ b/_locales/krc/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "<a href='$1'>$2</a> – Видео $3/$4",
+    "message": "<a href='$1' target='_blank'>$2</a> – Видео $3/$4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/lmo/messages.json
+++ b/_locales/lmo/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "de <a href='$1'>$2</a> - Video $3 de $4",
+    "message": "de <a href='$1' target='_blank'>$2</a> - Video $3 de $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/mk/messages.json
+++ b/_locales/mk/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "од <a href='$1'>$2</a> — Видео $3 од $4",
+    "message": "од <a href='$1' target='_blank'>$2</a> — Видео $3 од $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/ms/messages.json
+++ b/_locales/ms/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "karya <a href='$1'>$2</a> – Video $3 dari $4",
+    "message": "karya <a href='$1' target='_blank'>$2</a> – Video $3 dari $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/nb/messages.json
+++ b/_locales/nb/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "av <a href='$1'>$2</a> – video $3 av $4",
+    "message": "av <a href='$1' target='_blank'>$2</a> – video $3 av $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/pt-br/messages.json
+++ b/_locales/pt-br/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "por <a href='$1'>$2</a> – Vídeo $3 de $4",
+    "message": "por <a href='$1' target='_blank'>$2</a> – Vídeo $3 de $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/pt/messages.json
+++ b/_locales/pt/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "de <a href='$1'>$2</a> – Vídeo $3 de $4",
+    "message": "de <a href='$1' target='_blank'>$2</a> – Vídeo $3 de $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "авторство: <a href='$1'>$2</a> – видео $3 в $4",
+    "message": "авторство: <a href='$1' target='_blank'>$2</a> – видео $3 в $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/scn/messages.json
+++ b/_locales/scn/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "di <a href='$1'>$2</a> – Vìdiu $3 di $4",
+    "message": "di <a href='$1' target='_blank'>$2</a> – Vìdiu $3 di $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/sl/messages.json
+++ b/_locales/sl/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "avtor <a href='$1'>$2</a> – video $3 od $4",
+    "message": "avtor <a href='$1' target='_blank'>$2</a> – video $3 od $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/sv/messages.json
+++ b/_locales/sv/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "av <a href='$1'>$2</a> – Video $3 av $4",
+    "message": "av <a href='$1' target='_blank'>$2</a> – Video $3 av $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/tl/messages.json
+++ b/_locales/tl/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "ni <a href='$1'>$2</a> - Video $3 ng $4",
+    "message": "ni <a href='$1' target='_blank'>$2</a> - Video $3 ng $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/tr/messages.json
+++ b/_locales/tr/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "<a href='$1'>$2</a> – Video $3/$4",
+    "message": "<a href='$1' target='_blank'>$2</a> – Video $3/$4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/uk/messages.json
+++ b/_locales/uk/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "від <a href='$1'>$2</a> – Відео $3 із $4",
+    "message": "від <a href='$1' target='_blank'>$2</a> – Відео $3 із $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/ur/messages.json
+++ b/_locales/ur/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "<a href='$1'>$2</a> $4 توں ویڈیو $3 بݨائی اے",
+    "message": "<a href='$1' target='_blank'>$2</a> $4 توں ویڈیو $3 بݨائی اے",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/zh-hans/messages.json
+++ b/_locales/zh-hans/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "贡献者 <a href='$1'>$2</a> – 视频 $3 / $4",
+    "message": "贡献者 <a href='$1' target='_blank'>$2</a> – 视频 $3 / $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/zh-hant/messages.json
+++ b/_locales/zh-hant/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "貢獻者：<a href='$1'>$2</a> – 影片$3/$4",
+    "message": "貢獻者：<a href='$1' target='_blank'>$2</a> – 影片$3/$4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/i18n/anp.json
+++ b/i18n/anp.json
@@ -8,7 +8,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Lingua Libre प उपलब्ध सब्भे वीडियो क सूची प्राप्त होय रहलौ छौं।",
 	"si-panel-videos-title": "मीडिया:",
-	"si-panel-videos-gallery-attribution": "<a href='$1'>$2</a> द्वारा – $4 मँ सँ $3 नंबरिया वीडियो",
+	"si-panel-videos-gallery-attribution": "<a href='$1' target='_blank'>$2</a> द्वारा – $4 मँ सँ $3 नंबरिया वीडियो",
 	"si-panel-videos-empty": "हैय शब्द क एखनी तलक रिकॉर्ड नाय करलौ गेलौ छौं,<br>किंतु SignIt, लोगौ सिनी द्वारा बनैलौ गेलौ एगो परियोजना छेकै, आरो तोंय एकरा मँ योगदान करै सकै छौ।",
 	"si-panel-videos-contribute-label": "सांकेतिक भाषा प योगदान करौ",
 	"si-panel-definitions-title": "परिभाषा:",

--- a/i18n/az.json
+++ b/i18n/az.json
@@ -8,7 +8,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Lingua Libre-də mövcud olan bütün videoların siyahısı gətirilir.",
 	"si-panel-videos-title": "Media:",
-	"si-panel-videos-gallery-attribution": "<a href='$1'>$2</a> – Video $3/$4",
+	"si-panel-videos-gallery-attribution": "<a href='$1' target='_blank'>$2</a> – Video $3/$4",
 	"si-panel-videos-empty": "Bu söz hələ qeydə alınmayıb,<br> lakin SignIt icma əsaslı layihədir, siz ona töhfə verə bilərsiniz.",
 	"si-panel-videos-contribute-label": "İşarə dili ilə töhfə verin",
 	"si-panel-definitions-title": "Təriflər:",

--- a/i18n/blk.json
+++ b/i18n/blk.json
@@ -7,7 +7,7 @@
 	"si-addon-title": "လိင်းကွာလီဗာရယ်ကို တဲမ်းသွော့ꩻစူမုဲင်",
 	"si-addon-preload": "Lingua Libreအကို ကလꩻနွောင်ꩻဒါႏ ထူႏလꩻ ဗီဒီယိုဖုံႏ ကားကအဝ်ႏယိုလိတ်ထွိုင်။",
 	"si-panel-videos-title": "မီဒီယာ:",
-	"si-panel-videos-gallery-attribution": "<a href='$1'>$2</a>တွမ်ႏ – ဗီဒီယို $3 ယို $4",
+	"si-panel-videos-gallery-attribution": "<a href='$1' target='_blank'>$2</a>တွမ်ႏ – ဗီဒီယို $3 ယို $4",
 	"si-panel-videos-contribute-label": "နွို့စွဲးကမ်းငီꩻသွော့ꩻတွမ်ႏဘာႏသာႏငဝ်းငွါစူမုဲင်",
 	"si-panel-definitions-title": "အဓိပ္ပာယ်ႏဗွောင်နယ်ဆင်ႏ:",
 	"si-panel-definitions-wikt-iso": "အေင်ႏကလေတ်",

--- a/i18n/bn.json
+++ b/i18n/bn.json
@@ -8,7 +8,7 @@
 	"si-addon-title": "লিঙ্গুয়া লিব্রে সাইনইট",
 	"si-addon-preload": "Lingua Libre-এ উপলব্ধ সমস্ত ভিডিওর তালিকা আনা হচ্ছে।",
 	"si-panel-videos-title": "মিডিয়া:",
-	"si-panel-videos-gallery-attribution": "<a href='$1'>$2</a> দ্বারা – $4 এর মধ্যে $3 নং ভিডিও",
+	"si-panel-videos-gallery-attribution": "<a href='$1' target='_blank'>$2</a> দ্বারা – $4 এর মধ্যে $3 নং ভিডিও",
 	"si-panel-videos-empty": "এই শব্দটি এখনও রেকর্ড করা হয়নি,<br>তবে SignIt একটি ক্রাউড সোর্স প্রকল্প, আপনি এতে অবদান রাখতে পারেন।",
 	"si-panel-videos-contribute-label": "ইশারা ভাষার মাধ্যমে অবদান রাখুন",
 	"si-panel-definitions-title": "সংজ্ঞা:",

--- a/i18n/br.json
+++ b/i18n/br.json
@@ -7,7 +7,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "O kargañ ar videoioù da gaout war Ligua Libre.",
 	"si-panel-videos-title": "Media:",
-	"si-panel-videos-gallery-attribution": "gant <a href='$1'>$2</a> – $3 eus $4 video",
+	"si-panel-videos-gallery-attribution": "gant <a href='$1' target='_blank'>$2</a> – $3 eus $4 video",
 	"si-panel-videos-empty": "N'eo bet bet enrollet ar ger-se c'hoazh,<br>SignIt zo ur raktres kenlabourat avat ha gallout 'rit degas ho lod ivez.",
 	"si-panel-videos-contribute-label": "Kendeurel gant yezh ar sinoù",
 	"si-panel-definitions-title": "Termenadurioù:",

--- a/i18n/ce.json
+++ b/i18n/ce.json
@@ -7,7 +7,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Lingua Libre тӀехь йолу йерриге видео могӀам гойту.",
 	"si-panel-videos-title": "Медиа:",
-	"si-panel-videos-gallery-attribution": "авторалла: <a href='$1'>$2</a> – $3 видео $4 чохь",
+	"si-panel-videos-gallery-attribution": "авторалла: <a href='$1' target='_blank'>$2</a> – $3 видео $4 чохь",
 	"si-panel-videos-empty": "И дош хӀинца а дӀайаздина дац,<br> делахь SignIt — краудсорсинган проект йу, цундела ахьа къахьега мега!",
 	"si-panel-definitions-title": "Билгалдалар:",
 	"si-panel-definitions-wikt-iso": "en",

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -8,7 +8,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Abruf der Liste aller auf Lingua Libre verfügbaren Videos.",
 	"si-panel-videos-title": "Medien:",
-	"si-panel-videos-gallery-attribution": "von <a href='$1'>$2</a> – Video $3 von $4",
+	"si-panel-videos-gallery-attribution": "von <a href='$1' target='_blank'>$2</a> – Video $3 von $4",
 	"si-panel-videos-empty": "Dieses Wort wurde noch nicht aufgenommen,<br>aber SignIt ist ein Crowd-Sourced-Projekt, zu dem du beitragen kannst.",
 	"si-panel-videos-contribute-label": "Mit Gebärdensprache beitragen",
 	"si-panel-definitions-title": "Definitionen:",

--- a/i18n/diq.json
+++ b/i18n/diq.json
@@ -6,7 +6,7 @@
 	},
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-panel-videos-title": "Medya:",
-	"si-panel-videos-gallery-attribution": "Be <a href='$1'>$2</a> ra – Video $3 yê $4",
+	"si-panel-videos-gallery-attribution": "Be <a href='$1' target='_blank'>$2</a> ra – Video $3 yê $4",
 	"si-panel-definitions-title": "Şınasiye:",
 	"si-panel-definitions-wikt-pointer": "Wikiqısebend dı bıvin",
 	"si-panel-definitions-empty": "Sınasnayış nëvineya",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -9,7 +9,7 @@
 	"si-addon-preload": "Fetching the list of all videos available on Lingua Libre.",
 
 	"si-panel-videos-title":"Media:",
-	"si-panel-videos-gallery-attribution": "by <a href='$1'>$2</a> – Video $3 of $4",
+	"si-panel-videos-gallery-attribution": "by <a href='$1' target='_blank'>$2</a> – Video $3 of $4",
 	"si-panel-videos-empty":"This word hasn't been recorded yet,<br>but SignIt is crowd sourced project, you can contribute to it.",
 	"si-panel-videos-contribute-label":"Contribute with Sign Language",
 

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -8,7 +8,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Obteniendo la lista de todos los videos disponibles en Lingua Libre.",
 	"si-panel-videos-title": "Vídeo o audio:",
-	"si-panel-videos-gallery-attribution": "por <a href='$1'>$2</a> – Video $3 de $4",
+	"si-panel-videos-gallery-attribution": "por <a href='$1' target='_blank'>$2</a> – Video $3 de $4",
 	"si-panel-videos-empty": "Esta palabra aún no ha sido grabada,<br> pero SignIt es un proyecto colaborativo, ¡puedes contribuir a él!",
 	"si-panel-videos-contribute-label": "Contribuye con Lengua de señas",
 	"si-panel-definitions-title": "Definiciones:",

--- a/i18n/fa.json
+++ b/i18n/fa.json
@@ -8,7 +8,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "در حال واکشی لیست همهٔ ویدیوهای موجود در Lingua Libre.",
 	"si-panel-videos-title": "رسانه:",
-	"si-panel-videos-gallery-attribution": "توسط <a href='$1'>$2</a> – ویدئو $3 از میان $4",
+	"si-panel-videos-gallery-attribution": "توسط <a href='$1' target='_blank'>$2</a> – ویدئو $3 از میان $4",
 	"si-panel-videos-empty": "این کلمه هنوز ثبت نشده است،<br>اما SignIt یک پروژهٔ جمعی است، می‌توانید در آن مشارکت کنید.",
 	"si-panel-videos-contribute-label": "با زبان اشاره همکاری کنید",
 	"si-panel-definitions-title": "تعاریف:",

--- a/i18n/fi.json
+++ b/i18n/fi.json
@@ -7,7 +7,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Haetaan luetteloa kaikista Lingua Libressä saatavilla olevista videoista.",
 	"si-panel-videos-title": "Media:",
-	"si-panel-videos-gallery-attribution": "tekijä: <a href='$1'>$2</a> – Video $3 / $4",
+	"si-panel-videos-gallery-attribution": "tekijä: <a href='$1' target='_blank'>$2</a> – Video $3 / $4",
 	"si-panel-videos-empty": "Tätä sanaa ei ole vielä tallennettu,<br> mutta SignIt on joukkolähdeprojekti, voit osallistua siihen.",
 	"si-panel-videos-contribute-label": "Osallistu viittomakielellä",
 	"si-panel-definitions-title": "Määritelmät:",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -10,7 +10,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Chargement des vidéos disponibles sur Lingua Libre.",
 	"si-panel-videos-title": "Média :",
-	"si-panel-videos-gallery-attribution": "par <a href='$1'>$2</a> – Vidéo $3 sur $4",
+	"si-panel-videos-gallery-attribution": "par <a href='$1' target='_blank'>$2</a> – Vidéo $3 sur $4",
 	"si-panel-videos-empty": "Ce mot n’a pas encore été enregistré<br/> mais SignIt est un projet participatif auquel vous pouvez prendre part.",
 	"si-panel-videos-contribute-label": "Contribuer en langue des signes",
 	"si-panel-definitions-title": "Définitions :",

--- a/i18n/gl.json
+++ b/i18n/gl.json
@@ -7,7 +7,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Buscando a lista de todos os vídeos dispoñibles en Lingua Libre.",
 	"si-panel-videos-title": "Multimedia:",
-	"si-panel-videos-gallery-attribution": "por <a href='$1'>$2</a> – Vídeo $3 de $4",
+	"si-panel-videos-gallery-attribution": "por <a href='$1' target='_blank'>$2</a> – Vídeo $3 de $4",
 	"si-panel-videos-empty": "Aínda non se gravou esta palabra,<br>pero SignIt é un proxecto colaborativo e podes contribuír a el.",
 	"si-panel-videos-contribute-label": "Contribuír en lingua de sinais",
 	"si-panel-definitions-title": "Definicións:",

--- a/i18n/he.json
+++ b/i18n/he.json
@@ -8,7 +8,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "אחזור רשימת כל הסרטים הזמינים בלינגווה ליברה.",
 	"si-panel-videos-title": "מדיה:",
-	"si-panel-videos-gallery-attribution": "מאת <a href='$1'>$2</a> – סרט $3 מתוך $4",
+	"si-panel-videos-gallery-attribution": "מאת <a href='$1' target='_blank'>$2</a> – סרט $3 מתוך $4",
 	"si-panel-videos-empty": "המילה הזאת עוד לא הוקלטה,<br>אבל SignIt הוא מיזם במיקור המונים, אז יש לך הזדמנות לתרום לו.",
 	"si-panel-videos-contribute-label": "תרומה בשפת סימנים",
 	"si-panel-definitions-title": "הגדרות:",

--- a/i18n/hi.json
+++ b/i18n/hi.json
@@ -9,7 +9,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Lingua Libre पर उपलब्ध सभी वीडियों की सूची प्राप्त की जा रही है।",
 	"si-panel-videos-title": "मीडिया:",
-	"si-panel-videos-gallery-attribution": "<a href='$1'>$2</a> द्वारा – $4 में से $3 नंबरी वीडियो",
+	"si-panel-videos-gallery-attribution": "<a href='$1' target='_blank'>$2</a> द्वारा – $4 में से $3 नंबरी वीडियो",
 	"si-panel-videos-empty": "इस शब्द को अभी तक रिकॉर्ड नहीं किया गया है,<br>मगर SignIt, लोगों द्वारा बनाई गई एक परियोजना है, और आप इसमें योगदान कर सकते हैं।",
 	"si-panel-videos-contribute-label": "सांकेतिक भाषा पर योगदान करें",
 	"si-panel-definitions-title": "परिभाषाएँ:",

--- a/i18n/hy.json
+++ b/i18n/hy.json
@@ -9,7 +9,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Տալիս է Lingua Libre-ում հասանելի բոլոր տեսանյութերի ցուցակը:",
 	"si-panel-videos-title": "Մեդիա․",
-	"si-panel-videos-gallery-attribution": "հեղինակ՝ <a href='$1'>$2</a> – տեսանյութ $3 $4-ից",
+	"si-panel-videos-gallery-attribution": "հեղինակ՝ <a href='$1' target='_blank'>$2</a> – տեսանյութ $3 $4-ից",
 	"si-panel-videos-empty": "Այս բառը դեռ ձայնագրված չէ,<br> բայց SignIt-ը քրաուդսորսինգային նախագիծ է, և դուք կարող եք ներդնել ձեր ավանդը:",
 	"si-panel-videos-contribute-label": "Ներդրեք ձեր ավանդը ժեստերի լեզվով",
 	"si-panel-definitions-title": "Սահմանումներ․",

--- a/i18n/ia.json
+++ b/i18n/ia.json
@@ -7,7 +7,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Obtenente le lista de tote le videos disponibile sur Lingua Libre.",
 	"si-panel-videos-title": "Multimedia:",
-	"si-panel-videos-gallery-attribution": "per <a href='$1'>$2</a> – Video $3 de $4",
+	"si-panel-videos-gallery-attribution": "per <a href='$1' target='_blank'>$2</a> – Video $3 de $4",
 	"si-panel-videos-empty": "Iste parola non ha ancora essite registrate,<br>ma SignIt es un projecto participative al qual tu pote contribuer.",
 	"si-panel-videos-contribute-label": "Contribuer con linguage de signos",
 	"si-panel-definitions-title": "Definitiones:",

--- a/i18n/id.json
+++ b/i18n/id.json
@@ -10,7 +10,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Mengambil daftar semua video yang tersedia di Lingua Libre.",
 	"si-panel-videos-title": "Media:",
-	"si-panel-videos-gallery-attribution": "oleh <a href='$1'>$2</a> – Video $3 dari $4",
+	"si-panel-videos-gallery-attribution": "oleh <a href='$1' target='_blank'>$2</a> – Video $3 dari $4",
 	"si-panel-videos-empty": "Kata ini belum direkam,<br>tetapi karena SignIt adalah proyek urun daya, Anda dapat ikut berkontribusi.",
 	"si-panel-videos-contribute-label": "Berkontribusi dengan Bahasa Isyarat",
 	"si-panel-definitions-title": "Definisi:",

--- a/i18n/it.json
+++ b/i18n/it.json
@@ -10,7 +10,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Recupero l'elenco di tutti i video disponibili su Lingua Libre.",
 	"si-panel-videos-title": "Media:",
-	"si-panel-videos-gallery-attribution": "di <a href='$1'>$2</a> - Video $3 di $4",
+	"si-panel-videos-gallery-attribution": "di <a href='$1' target='_blank'>$2</a> - Video $3 di $4",
 	"si-panel-videos-empty": "Questa parola non è stata ancora registrata,<br>ma SignIt è un progetto in crowdsourcing, puoi contribuire anche tu.",
 	"si-panel-videos-contribute-label": "Contribuisci con la lingua dei segni",
 	"si-panel-definitions-title": "Definizioni:",

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -14,7 +14,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Lingua Libreの利用可能なすべての動画のリストを取得しています。",
 	"si-panel-videos-title": "メディア:",
-	"si-panel-videos-gallery-attribution": "<a href='$1'>$2</a>に帰属  – 動画 $4件中の$3件目",
+	"si-panel-videos-gallery-attribution": "<a href='$1' target='_blank'>$2</a>に帰属  – 動画 $4件中の$3件目",
 	"si-panel-videos-empty": "この言葉はまだ記録されていません<br>SignItから手話を投稿することもできます。",
 	"si-panel-videos-contribute-label": "手話で貢献する",
 	"si-panel-definitions-title": "定義:",

--- a/i18n/kk-cyrl.json
+++ b/i18n/kk-cyrl.json
@@ -9,7 +9,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Lingua Libre-де қолжетімді барлық видео тізімі алынып жатыр.",
 	"si-panel-videos-title": "Медиа:",
-	"si-panel-videos-gallery-attribution": "ауторы: <a href='$1'>$2</a> — $3/$4 видео",
+	"si-panel-videos-gallery-attribution": "ауторы: <a href='$1' target='_blank'>$2</a> — $3/$4 видео",
 	"si-panel-videos-empty": "Бұл сөз әлі жазылмаған,<br>бірақ SignIt краудсорсиң жобасы болғандықтан, сіз оған үлес қоса аласыз.",
 	"si-panel-videos-contribute-label": "Ым тілінмен үлес қосу",
 	"si-panel-definitions-title": "Мағыналары:",

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -9,7 +9,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Lingua Libre에서 사용 가능한 모든 동영상의 목록을 가져옵니다.",
 	"si-panel-videos-title": "미디어:",
-	"si-panel-videos-gallery-attribution": "만든이: <a href='$1'>$2</a> – 동영상 $3 / $4",
+	"si-panel-videos-gallery-attribution": "만든이: <a href='$1' target='_blank'>$2</a> – 동영상 $3 / $4",
 	"si-panel-videos-empty": "이 단어는 아직 녹화되지 않았습니다.<br>SignIt은 크라우드 소싱 프로젝트이므로 직접 기여할 수 있습니다.",
 	"si-panel-videos-contribute-label": "수화로 기여",
 	"si-panel-definitions-title": "정의:",

--- a/i18n/krc.json
+++ b/i18n/krc.json
@@ -7,7 +7,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Lingua Libre-де болгъан бютеу видеоланы тизмесин келтиреди.",
 	"si-panel-videos-title": "Медиа:",
-	"si-panel-videos-gallery-attribution": "<a href='$1'>$2</a> – Видео $3/$4",
+	"si-panel-videos-gallery-attribution": "<a href='$1' target='_blank'>$2</a> – Видео $3/$4",
 	"si-panel-videos-empty": "Бу сёз алкъын джаздырылмагъанды<br> алай а SignIt краудсорсинг проект болгъаны себебли, кесигизни юлюшюгюзню къошаргъа боллукъсуз.",
 	"si-panel-videos-contribute-label": "Къол силкиу тилде кесигизни юлюшюгюзню къошугъуз",
 	"si-panel-definitions-title": "Ачыкълау:",

--- a/i18n/lmo.json
+++ b/i18n/lmo.json
@@ -7,7 +7,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Adree a portà a voltra la lista de tucc i video disponibil in su Lengua Libre.",
 	"si-panel-videos-title": "Media:",
-	"si-panel-videos-gallery-attribution": "de <a href='$1'>$2</a> - Video $3 de $4",
+	"si-panel-videos-gallery-attribution": "de <a href='$1' target='_blank'>$2</a> - Video $3 de $4",
 	"si-panel-videos-empty": "Questa parolla chì l'è stada nan'mò registrada,<br>ma SignIt a l'è un proget in collaborazzion, te podet contribuì an' ti.",
 	"si-panel-videos-contribute-label": "Contribuiss con la lengua di segni",
 	"si-panel-definitions-title": "Definizzionː",

--- a/i18n/mk.json
+++ b/i18n/mk.json
@@ -8,7 +8,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Преземам список на сите видеоснимки достапни на Lingua Libre.",
 	"si-panel-videos-title": "Снимка:",
-	"si-panel-videos-gallery-attribution": "од <a href='$1'>$2</a> — Видео $3 од $4",
+	"si-panel-videos-gallery-attribution": "од <a href='$1' target='_blank'>$2</a> — Видео $3 од $4",
 	"si-panel-videos-empty": "Овој збор сè уште не е снимен,<br> но SignIt е проект со општо учество, и затоа и Вие можете да придонесувате.",
 	"si-panel-videos-contribute-label": "Учествувајте со знаковен јазик",
 	"si-panel-definitions-title": "Дефиниции:",

--- a/i18n/ms.json
+++ b/i18n/ms.json
@@ -8,7 +8,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Mengambil senarai semua video yang tersedia di Lingua Libre.",
 	"si-panel-videos-title": "Media:",
-	"si-panel-videos-gallery-attribution": "karya <a href='$1'>$2</a> – Video $3 dari $4",
+	"si-panel-videos-gallery-attribution": "karya <a href='$1' target='_blank'>$2</a> – Video $3 dari $4",
 	"si-panel-videos-empty": "Perkataan ini belum dirakam lagi,<br>tetapi SignIt adalah projek hasil usaha sama dari orang ramai, maka anda boleh memberi sumbangan.",
 	"si-panel-videos-contribute-label": "Menyumbang dengan Bahasa Isyarat",
 	"si-panel-definitions-title": "Definisi:",

--- a/i18n/nb.json
+++ b/i18n/nb.json
@@ -8,7 +8,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Henter lista over alle videoer som er tilgjengelig på Lingua Libre.",
 	"si-panel-videos-title": "Media:",
-	"si-panel-videos-gallery-attribution": "av <a href='$1'>$2</a> – video $3 av $4",
+	"si-panel-videos-gallery-attribution": "av <a href='$1' target='_blank'>$2</a> – video $3 av $4",
 	"si-panel-videos-empty": "Dette ordet har ikke blitt spilt inn ennå,<br>men SignIt er et dugnadsprosjekt, så du kan spille det inn.",
 	"si-panel-videos-contribute-label": "Bidra med tegnspråk",
 	"si-panel-definitions-title": "Definisjoner:",

--- a/i18n/pt-br.json
+++ b/i18n/pt-br.json
@@ -7,7 +7,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Buscando a lista de todos os vídeos disponíveis no Lingua Libre.",
 	"si-panel-videos-title": "Mídia:",
-	"si-panel-videos-gallery-attribution": "por <a href='$1'>$2</a> – Vídeo $3 de $4",
+	"si-panel-videos-gallery-attribution": "por <a href='$1' target='_blank'>$2</a> – Vídeo $3 de $4",
 	"si-panel-videos-empty": "Esta palavra ainda não foi gravada,<br /> mas SignIt é um projeto de crowdsourcingpara o qual você pode contribuir.",
 	"si-panel-videos-contribute-label": "Contribuir com a língua de sinais",
 	"si-panel-definitions-title": "Definições:",

--- a/i18n/pt.json
+++ b/i18n/pt.json
@@ -8,7 +8,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "A obter a lista de todos os vídeos disponíveis em Lingua Libre.",
 	"si-panel-videos-title": "Multimédia:",
-	"si-panel-videos-gallery-attribution": "de <a href='$1'>$2</a> – Vídeo $3 de $4",
+	"si-panel-videos-gallery-attribution": "de <a href='$1' target='_blank'>$2</a> – Vídeo $3 de $4",
 	"si-panel-videos-empty": "Esta palavra ainda não foi gravada,<br> mas como SignIt é um projeto de ''crowdsourcing'' pode participar nele.",
 	"si-panel-videos-contribute-label": "Contribuir com língua de sinais",
 	"si-panel-definitions-title": "Definições:",

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -8,7 +8,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Выдаёт список всех видео, доступных на Lingua Libre.",
 	"si-panel-videos-title": "Медиа:",
-	"si-panel-videos-gallery-attribution": "авторство: <a href='$1'>$2</a> – видео $3 в $4",
+	"si-panel-videos-gallery-attribution": "авторство: <a href='$1' target='_blank'>$2</a> – видео $3 в $4",
 	"si-panel-videos-empty": "Это слово еще не записано,<br> но SignIt — это краудсорсинговый проект, и вы можете внести свой вклад!",
 	"si-panel-videos-contribute-label": "Внесите свой вклад на жестовом языке",
 	"si-panel-definitions-title": "Определения:",

--- a/i18n/scn.json
+++ b/i18n/scn.json
@@ -7,7 +7,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Carricamentu di l'alencu di tutti li vìdii dispunìbbili supra Lingua Libre.",
 	"si-panel-videos-title": "Midia:",
-	"si-panel-videos-gallery-attribution": "di <a href='$1'>$2</a> – Vìdiu $3 di $4",
+	"si-panel-videos-gallery-attribution": "di <a href='$1' target='_blank'>$2</a> – Vìdiu $3 di $4",
 	"si-panel-videos-empty": "Sta palora nun è ancora riggistrata,<br>pirò SignIt è nu pruggettu participativu, a cui tu poi cuntribbuiri.",
 	"si-panel-videos-contribute-label": "Cuntribbuisci ntâ lingua dî signa",
 	"si-panel-definitions-title": "Difinizzioni:",

--- a/i18n/sl.json
+++ b/i18n/sl.json
@@ -7,7 +7,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Pridobivanje seznama vseh videoposnetkov, ki so na voljo v Lingua Libre.",
 	"si-panel-videos-title": "Predstavnosti:",
-	"si-panel-videos-gallery-attribution": "avtor <a href='$1'>$2</a> – video $3 od $4",
+	"si-panel-videos-gallery-attribution": "avtor <a href='$1' target='_blank'>$2</a> – video $3 od $4",
 	"si-panel-videos-empty": "Ta beseda še ni bila zapisana,<br> vendar je SignIt sodelovalni projekt in lahko prispevate k njemu.",
 	"si-panel-videos-contribute-label": "Prispevajte z znakovnim jezikom",
 	"si-panel-definitions-title": "Opredelitve:",

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -7,7 +7,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Hämtar listan över alla tillgängliga videor på Lingua Libre.",
 	"si-panel-videos-title": "Media:",
-	"si-panel-videos-gallery-attribution": "av <a href='$1'>$2</a> – Video $3 av $4",
+	"si-panel-videos-gallery-attribution": "av <a href='$1' target='_blank'>$2</a> – Video $3 av $4",
 	"si-panel-videos-empty": "Det här ordet har ännu inte spelats in,<br>men SignIt är ett samarbetsprojekt så du kan bidra med det.",
 	"si-panel-videos-contribute-label": "Bidra med teckenspråk",
 	"si-panel-definitions-title": "Definitioner:",

--- a/i18n/tl.json
+++ b/i18n/tl.json
@@ -7,7 +7,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Kinukuha ang listahan ng lahat ng mga magagamit na video sa Lingua Libre.",
 	"si-panel-videos-title": "Midya:",
-	"si-panel-videos-gallery-attribution": "ni <a href='$1'>$2</a> - Video $3 ng $4",
+	"si-panel-videos-gallery-attribution": "ni <a href='$1' target='_blank'>$2</a> - Video $3 ng $4",
 	"si-panel-videos-empty": "Hindi pa nare-record ang salitang ito,<b4>pero crowdsourced na proyekto ang SignIt, kaya naman pwede kang mag-ambag rito.",
 	"si-panel-videos-contribute-label": "Mag-ambag gamit ang Wikang Nakasenyas",
 	"si-panel-definitions-title": "Mga kahulugan:",

--- a/i18n/tr.json
+++ b/i18n/tr.json
@@ -7,7 +7,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Lingua Libre'de bulunan tüm videoların listesi getiriliyor.",
 	"si-panel-videos-title": "Medya:",
-	"si-panel-videos-gallery-attribution": "<a href='$1'>$2</a> – Video $3/$4",
+	"si-panel-videos-gallery-attribution": "<a href='$1' target='_blank'>$2</a> – Video $3/$4",
 	"si-panel-videos-empty": "Bu kelime henüz kaydedilmedi<br> ancak SignIt kitle kaynaklı bir projedir ve SignIt'e katkıda bulunabilirsiniz.",
 	"si-panel-videos-contribute-label": "İşaret Dili ile Katkıda Bulunun",
 	"si-panel-definitions-title": "Tanımlar:",

--- a/i18n/uk.json
+++ b/i18n/uk.json
@@ -7,7 +7,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Отримання списку всіх відео, доступних на Lingua Libre.",
 	"si-panel-videos-title": "Медіа:",
-	"si-panel-videos-gallery-attribution": "від <a href='$1'>$2</a> – Відео $3 із $4",
+	"si-panel-videos-gallery-attribution": "від <a href='$1' target='_blank'>$2</a> – Відео $3 із $4",
 	"si-panel-videos-empty": "Це слово ще не записано,<br> але SignIt – це проект, створений натовпом, ви можете зробити свій внесок у нього.",
 	"si-panel-videos-contribute-label": "Зробіть внесок Мовою Жестів",
 	"si-panel-definitions-title": "Визначення:",

--- a/i18n/ur.json
+++ b/i18n/ur.json
@@ -7,7 +7,7 @@
 	"si-addon-title": "آزاد سائین بولی والا",
 	"si-addon-preload": "ساریاں ویڈیواں لبھیاں جا رہیاں۔",
 	"si-panel-videos-title": "میڈیا:",
-	"si-panel-videos-gallery-attribution": "<a href='$1'>$2</a> $4 توں ویڈیو $3 بݨائی اے",
+	"si-panel-videos-gallery-attribution": "<a href='$1' target='_blank'>$2</a> $4 توں ویڈیو $3 بݨائی اے",
 	"si-panel-videos-empty": "حالیہ ریکارڈ نہیں لبھیا،<br>پر تسیں ریکارڈ کر سکیو۔",
 	"si-panel-videos-contribute-label": "سائین بھاشا ورتو",
 	"si-panel-definitions-title": "تعریفاں:",

--- a/i18n/zh-hans.json
+++ b/i18n/zh-hans.json
@@ -10,7 +10,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "获取 Lingua Libre 上可提供的视频列表。",
 	"si-panel-videos-title": "视频：",
-	"si-panel-videos-gallery-attribution": "贡献者 <a href='$1'>$2</a> – 视频 $3 / $4",
+	"si-panel-videos-gallery-attribution": "贡献者 <a href='$1' target='_blank'>$2</a> – 视频 $3 / $4",
 	"si-panel-videos-empty": "该词汇尚无视频，<br>不过 SignIt 是一项众包项目，您可以参与其中并帮助完成。",
 	"si-panel-videos-contribute-label": "贡献你的手语",
 	"si-panel-definitions-title": "定义：",

--- a/i18n/zh-hant.json
+++ b/i18n/zh-hant.json
@@ -9,7 +9,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "取得在 Lingua Libre 上的所有可用影片清單。",
 	"si-panel-videos-title": "媒體：",
-	"si-panel-videos-gallery-attribution": "貢獻者：<a href='$1'>$2</a> – 影片$3/$4",
+	"si-panel-videos-gallery-attribution": "貢獻者：<a href='$1' target='_blank'>$2</a> – 影片$3/$4",
 	"si-panel-videos-empty": "SignIt 是個群眾外包專案，<br>因此目前雖然尚無該字詞的影片，您可以參與其中來協助完成。",
 	"si-panel-videos-contribute-label": "以手語貢獻",
 	"si-panel-definitions-title": "定義：",

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
 	"manifest_version": 3,
-	"name": "__MSG_extensionName__",	
+	"name": "__MSG_si_addon_title__",	
 	"version": "1.0.22",
 	"author": "Antoine '0x010C' Lamielle, Hugo Lopez",
-	"description": "__MSG_extensionDescription__",
+	"description": "SignIt translate a selected word into Sign Language videos.",
 	"homepage_url": "https://lingualibre.org",
 	"icons": {
 	  "32": "icons/Lingualibre_SignIt-logo-no-text-square-32.png",

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
 	"manifest_version": 3,
-	"name": "Lingua Libre SignIt",
+	"name": "__MSG_extensionName__",	
 	"version": "1.0.22",
 	"author": "Antoine '0x010C' Lamielle, Hugo Lopez",
-	"description": "SignIt translate a selected word into Sign Language videos.",
+	"description": "__MSG_extensionDescription__",
 	"homepage_url": "https://lingualibre.org",
 	"icons": {
 	  "32": "icons/Lingualibre_SignIt-logo-no-text-square-32.png",

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -50,12 +50,12 @@ var browser = (browserType === 'firefox') ? browser : (browserType === 'chrome')
 	/* *********************************************************** */
 	// Master
 	var UI = function () {
-		document.querySelector('#fetchVideosList').innerHTML = banana.i18n('si-addon-preload');
+		document.querySelector('#fetchVideosList').innerHTML = browser.i18n.getMessage('si_addon_preload');
 
 		// Setup the main tabs
-		this.viewTab = new OO.ui.TabPanelLayout( 'view', { label: banana.i18n('si-popup-browse-title') } );
-		this.historyTab = new OO.ui.TabPanelLayout( 'history', { label: banana.i18n('si-popup-history-title'), classes: [ 'signit-popup-tab-history' ] } );
-		this.paramTab = new OO.ui.TabPanelLayout( 'param', { label: banana.i18n('si-popup-settings-title'), classes: [ 'signit-popup-tab-settings' ] } );
+		this.viewTab = new OO.ui.TabPanelLayout( 'view', { label: browser.i18n.getMessage('si_popup_browse_title') } );
+		this.historyTab = new OO.ui.TabPanelLayout( 'history', { label: browser.i18n.getMessage('si_popup_history_title'), classes: [ 'signit-popup-tab-history' ] } );
+		this.paramTab = new OO.ui.TabPanelLayout( 'param', { label: browser.i18n.getMessage('si_popup_settings_title'), classes: [ 'signit-popup-tab-settings' ] } );
 
 		// Set up the popup page layout
 		this.indexLayout = new OO.ui.IndexLayout( { autoFocus: false, classes: [ 'signit-popup-tabs' ] } );
@@ -83,18 +83,19 @@ var browser = (browserType === 'firefox') ? browser : (browserType === 'chrome')
 	// Browse tab
 	UI.prototype.initView = async function () {
 		// Word input 2 : text field
-		this.searchWidget = new SearchWidget( { placeholder: banana.i18n("si-popup-browse-placeholder", Object.keys( _backgroundPage.records ).length ) } );
+		// browser.i18n.getMessage accepts string value as substitutes for placeholders, hence JSON.stringify
+		this.searchWidget = new SearchWidget( { placeholder: browser.i18n.getMessage("si_popup_browse_placeholder", JSON.stringify(Object.keys( _backgroundPage.records ).length) ) } );
 		this.searchWidget.setRecords( _backgroundPage.records );
 		var searchButton = new OO.ui.ButtonWidget( {
 			icon:"search",
-			label: banana.i18n("si-popup-browse-label"),
+			label: browser.i18n.getMessage("si_popup_browse_label"),
 			invisibleLabel: true,
-			title: banana.i18n("si-popup-browse-icon")
+			title: browser.i18n.getMessage("si_popup_browse_icon")
 		} );
 		
 		var searchLayout = new OO.ui.ActionFieldLayout( this.searchWidget, searchButton, {
 			align: 'top',
-			label: banana.i18n("si-popup-browse-label"),
+			label: browser.i18n.getMessage("si_popup_browse_label"),
 			invisibleLabel: true,
 			classes: [ 'signit-popup-tab-browse' ]
 		} );
@@ -115,7 +116,7 @@ var browser = (browserType === 'firefox') ? browser : (browserType === 'chrome')
 		var tabs = await browser.tabs.query({active: true, currentWindow: true});
 		
 		// optimizing message passing for the functions that are present in 
-		// sw.js as well background-script.js
+		// sw.js as well background_script.js
 
 		await sendMessageUp("checkActiveTabInjections",tabs[0].id);
 		var selection = await browser.tabs.sendMessage( tabs[ 0 ].id, {
@@ -147,7 +148,7 @@ var browser = (browserType === 'firefox') ? browser : (browserType === 'chrome')
 	// History tab 
 	// .initHistory calls .addHistory which calls .cleanHistory
 	UI.prototype.initHistory = function () {
-		this.$noHistory = $( `<div>${banana.i18n("si-popup-history-empty")}</div>` );
+		this.$noHistory = $( `<div>${browser.i18n.getMessage("si_popup_history_empty")}</div>` );
 		this.history = [];
 		this.$history = [];
 		this.historyTab.$element.append( this.$noHistory );
@@ -212,14 +213,14 @@ var browser = (browserType === 'firefox') ? browser : (browserType === 'chrome')
 		}
 		// Layout
 		signLanguageDropdown = new OO.ui.DropdownWidget( { 
-			label: banana.i18n("si-popup-settings-signlanguage-dropdown"), 
+			label: browser.i18n.getMessage("si_popup_settings_signlanguage-dropdown"), 
 			menu: { items: items }, 
 			$overlay: $( 'body' ) 
 		} );
 		signLanguageLayout = new OO.ui.FieldLayout( signLanguageDropdown, {
-			label: banana.i18n("si-popup-settings-signlanguage"),
+			label: browser.i18n.getMessage("si_popup_settings_signlanguage"),
 			align: 'top',
-			help: banana.i18n("si-popup-settings-signlanguage-help"),
+			help: browser.i18n.getMessage("si_popup_settings_signlanguage-help"),
 			//helpInline: true
 		} );
 		
@@ -239,14 +240,14 @@ var browser = (browserType === 'firefox') ? browser : (browserType === 'chrome')
 		}
 		// Layout
 		uiLanguageDropdown = new OO.ui.DropdownWidget({ 
-			label: banana.i18n("si-popup-settings-signlanguage"), 
+			label: browser.i18n.getMessage("si_popup-settings_signlanguage"), 
 			menu: { items: items }, 
 			$overlay: $( 'body' ) 
 		} );
 		uiLanguageLayout = new OO.ui.FieldLayout( uiLanguageDropdown, {
-			label: banana.i18n("si-popup-settings-uilanguage"),
+			label: browser.i18n.getMessage("si_popup_settings_uilanguage"),
 			align: 'top',
-			help: banana.i18n("si-popup-settings-uilanguage-help"),
+			help: browser.i18n.getMessage("si_popup_settings_uilanguage-help"),
 			//helpInline: true
 		} );
 
@@ -256,9 +257,9 @@ var browser = (browserType === 'firefox') ? browser : (browserType === 'chrome')
 			min: 0
 		} );
 		historyLayout = new OO.ui.FieldLayout( historyWidget, {
-			label: banana.i18n("si-popup-settings-history"),
+			label: browser.i18n.getMessage("si_popup_settings_history"),
 			align: 'top',
-			help: banana.i18n("si-popup-settings-history-help"),
+			help: browser.i18n.getMessage("si_popup_settings_history_help"),
 		} );
 
 		
@@ -268,7 +269,7 @@ var browser = (browserType === 'firefox') ? browser : (browserType === 'chrome')
 			selected: _backgroundPage.params.wpintegration,
 		} );
 		wpintegrationLayout = new OO.ui.FieldLayout( wpintegrationWidget, {
-			label: banana.i18n("si-popup-settings-wpintegration"),
+			label: browser.i18n.getMessage("si_popup_settings_wpintegration"),
 			align: 'inline',
 		} );
 
@@ -277,7 +278,7 @@ var browser = (browserType === 'firefox') ? browser : (browserType === 'chrome')
 			selected: _backgroundPage.params.twospeed,
 		} );
 		twospeedLayout = new OO.ui.FieldLayout( twospeedWidget, {
-			label: banana.i18n("si-popup-settings-twospeed"),
+			label: browser.i18n.getMessage("si_popup_settings_twospeed"),
 			align: 'inline',
 		} );
 		// Hint icon shortcut
@@ -285,7 +286,7 @@ var browser = (browserType === 'firefox') ? browser : (browserType === 'chrome')
       selected: _backgroundPage.params.hinticon,
     });
     hinticonLayout = new OO.ui.FieldLayout(hinticonWidget, {
-      label: banana.i18n('si-popup-settings-hint-icon'),
+      label: browser.i18n.getMessage('si_popup_settings_hint-icon'),
       align: 'inline',
     });
     // Colored text
@@ -293,29 +294,29 @@ var browser = (browserType === 'firefox') ? browser : (browserType === 'chrome')
       selected: _backgroundPage.params.coloredwords,
     });
     coloredwordsLayout = new OO.ui.FieldLayout(coloredwordsWidget, {
-      label: banana.i18n('si-popup-settings-enlighten'),
+      label: browser.i18n.getMessage('si_popup_settings_enlighten'),
       align: 'inline',
     });
 
 		// Choose panels : both, definition, video
 		var panelsOption0 = new OO.ui.ButtonOptionWidget( {
 			data: 'definition',
-			label: banana.i18n("si-popup-settings-choosepanels-definition")
+			label: browser.i18n.getMessage("si_popup_settings_choosepanels_definition")
 		} ),
 		panelsOption1 = new OO.ui.ButtonOptionWidget( {
 			data: 'both',
-			label: banana.i18n("si-popup-settings-choosepanels-both")
+			label: browser.i18n.getMessage("si_popup_settings_choosepanels_both")
 		} );
 		panelsOption2 = new OO.ui.ButtonOptionWidget( {
 			data: 'video',
-			label:  banana.i18n("si-popup-settings-choosepanels-video")
+			label:  browser.i18n.getMessage("si_popup_settings_choosepanels_video")
 		} );
 		choosepanelsWidget = new OO.ui.ButtonSelectWidget( {
 			items: [ panelsOption0, panelsOption1, panelsOption2 ]
 		} );
 		// Layout
 		choosepanelsLayout = new OO.ui.FieldLayout( choosepanelsWidget, {
-			label:  banana.i18n("si-popup-settings-choosepanels"),
+			label:  browser.i18n.getMessage("si_popup_settings_choosepanels"),
 			align: 'top',
 		} );
 


### PR DESCRIPTION
## Changes

- [4af82b](https://github.com/lingua-libre/SignIt/commit/4af82b64dc36049818bb0d02e17cf84615d7a6f2) - added `target='_blank'` so that  speaker url opens in new tab
- [d29827](https://github.com/lingua-libre/SignIt/commit/d298273d0d3bb8f76a18d8a4bd60c76caa92246d) - replacing `extensionName` in 3197d1 to `si_addon_title`
- [6bc7b9](https://github.com/lingua-libre/SignIt/commit/6bc7b9197a0f5e88053f7588963d7e73e398b885) - replaced `banana.i18n` with `browser.i18n.getMessage()` as addressed in #86 
## Result 

| Scope | Chrome | Firefox |
| --- | --- | --- |
| Popup > Settings  | ✔ | ✔ |
| Popup > Browse > video gallery | ✔ | ✔ |
| Content script > modal > video gallery  | ✔ | ✔ |

**NOTE:** When talking about settings , `changeUiLanguage` function is not being talked about