### PR TITLE
fix : i18n

### DIFF
--- a/SignItCoreContent.js
+++ b/SignItCoreContent.js
@@ -71,10 +71,9 @@ var SignItCoreContent = function () {
         const [videosPanelNoVideoTitle, videosPanelNoVideoEmpty, definitionsPanelTitle, contributeButtonLabel, wiktIso, wiktPointer, definitionsEmpty] = translations;
 
         this.$container.find(".signit-panel-videos .signit-novideo h2").text(videosPanelNoVideoTitle); 
-        this.$container.find(".signit-panel-videos .signit-novideo p").text(videosPanelNoVideoEmpty); // -- needs additional css
+        this.$container.find(".signit-panel-videos .signit-novideo p").html(videosPanelNoVideoEmpty); // -- needs additional css
         this.$container.find(".signit-panel-definitions .signit-definitions h2").text(definitionsPanelTitle); 
         this.contributeButton.$label.text(contributeButtonLabel);
-        
         const definitionsSourceLink = `https://${wiktIso}.wiktionary.org`;
         this.$container
           .find(".signit-definitions-source a")

--- a/SignItCoreContent.js
+++ b/SignItCoreContent.js
@@ -1,31 +1,23 @@
-var SignItCoreContent = function (locale,mapi18n) {
-  const sourceMap = new Map(mapi18n);
-  banana = { i18n: (msg) => sourceMap.get(locale)[msg] };
-  console.log("Passed trough ! :", locale);
-  console.log("SignItCoreContent.js",banana );
-  // let hlwa = browser.i18n.getMessage("si-panel-videos-title"); 
-  // console.log("hlwa = ",hlwa); 
+var SignItCoreContent = function () {
+  console.log("SignItCoreContent.js");
   this.$container = $(`
 		<div class="signit-modal-container">
 			<h1></h1>
 			<div class="signit-modal-content">
         <div class="signit-panel-videos">
           <div class="signit-panel-videos signit-novideo">
-            <h2>
-            ${ browser.i18n.getMessage("si_panel_videos_title") }</h2>
-            ${ browser.i18n.getMessage("si_panel_videos_empty") }<br><br>
+            <h2></h2>
+            <p></p>
           </div>
           <div class="signit-panel-videos signit-video"></div>
         </div>
 				<div class="signit-panel-separator"></div>
         <div class="signit-panel-definitions">
           <div class="signit-panel-definitions signit-definitions">
-            <h2>
-            ${ browser.i18n.getMessage("si_panel_definitions_title") }</h2>
+            <h2></h2>
             <div class="signit-definitions-text"></div>
             <div class="signit-definitions-source">
-              <a href="https://${ browser.i18n.getMessage("si_panel_definitions_wikt_iso") }.wiktionary.org">
-          ${ browser.i18n.getMessage("si_panel_definitions_wikt_pointer") }</a>
+              <a href></a>
             </div>
           </div>
           <div class="signit-panel-definitions signit-loading">
@@ -33,17 +25,14 @@ var SignItCoreContent = function (locale,mapi18n) {
               "icons/Spinner_font_awesome.svg"
             )}" width="40" height="40">
           </div>
-          <div class="signit-panel-definitions signit-error">
-          ${ browser.i18n.getMessage("si_panel_definitions_empty") }</div>
+          <div class="signit-panel-definitions signit-error"></div>
         </div>
 			</div>
 		</div>
 	  `);
-    
-    // Button contribute
     var optionsContribute = {
       flags: ["primary", "progressive"],
-      label: browser.i18n.getMessage("si_panel_videos_contribute_label") ,
+      label: " ",
       href: "https://lingualibre.org/wiki/Special:RecordWizard",
     };
     this.contributeButton = new OO.ui.ButtonWidget(optionsContribute);
@@ -62,9 +51,42 @@ var SignItCoreContent = function (locale,mapi18n) {
     this.$definitionPanelSpinner = this.$container.find(".signit-loading");
     this.$definitionPanelError = this.$container.find(".signit-error");
 
-    // this.contributeButton.on( 'click', function () {
-    //	// TODO: Do something
-    // }.bind( this ) );
+    SignItCoreContent.prototype.init = async function () {
+      try {
+        var banana = {i18n: async (msg,...arg) => {
+          return await chrome.runtime.sendMessage({
+            command:'bananai18n',arg : [msg,arg]
+          })
+        }
+      };
+        const translations = await Promise.all([
+          banana.i18n("si-panel-videos-title"),
+          banana.i18n("si-panel-videos-empty"),
+          banana.i18n("si-panel-definitions-title"),
+          banana.i18n("si-panel-videos-contribute-label"),
+          banana.i18n("si-panel-definitions-wikt-iso"),
+          banana.i18n("si-panel-definitions-wikt-pointer"),
+          banana.i18n("si-panel-definitions-empty") // May need a different key for error message
+        ]);
+        const [videosPanelNoVideoTitle, videosPanelNoVideoEmpty, definitionsPanelTitle, contributeButtonLabel, wiktIso, wiktPointer, definitionsEmpty] = translations;
+
+        this.$container.find(".signit-panel-videos .signit-novideo h2").text(videosPanelNoVideoTitle); 
+        this.$container.find(".signit-panel-videos .signit-novideo p").text(videosPanelNoVideoEmpty); // -- needs additional css
+        this.$container.find(".signit-panel-definitions .signit-definitions h2").text(definitionsPanelTitle); 
+        this.contributeButton.$label.text(contributeButtonLabel);
+        
+        const definitionsSourceLink = `https://${wiktIso}.wiktionary.org`;
+        this.$container
+          .find(".signit-definitions-source a")
+          .attr("href", definitionsSourceLink)
+          .text(wiktPointer);
+    
+        this.$container.find(".signit-panel-definitions .signit-error").text(definitionsEmpty);
+    
+      } catch (error) {
+        console.error("Error fetching translations:", error);
+      }
+    };
 
   SignItCoreContent.prototype.refresh = function (title, files) {
     files = files || [];

--- a/SignItVideosGallery.js
+++ b/SignItVideosGallery.js
@@ -17,22 +17,12 @@ var SignItVideosGallery = function ( container ) {
 };
 
 SignItVideosGallery.prototype.refresh = async function ( files ) {
-	var BetterBanana = await browser.storage.local.get( 'bananaInStore' );
-	var messageStore = await chrome.storage.local.get( 'sourceMap' ); 
-	var sourceMap = new Map(messageStore.sourceMap);
-	var locale = BetterBanana.bananaInStore.locale;
 	var banana = {
-    i18n: (msg, url, speaker,index, total) => {
-		let string = sourceMap.get(locale)[msg];
-		let Speaker = `<a href=${url} target="_blank">${speaker} </a>`;
-		let patterns = ["{{link|$1|$2}}", "$3", "$4"];
-		let replacements = [Speaker, index, total];
-
-		patterns.forEach((pattern,index)=>{
-			string = string.replace(pattern, replacements[index]);
-		})
-
-		return string;
+    i18n: async (msg, ...arg) => {
+      return await chrome.runtime.sendMessage({
+        command: "bananai18n",
+        arg: [msg, arg],
+      });
     },
   };
 	console.log("#20 files ",files )
@@ -40,19 +30,19 @@ SignItVideosGallery.prototype.refresh = async function ( files ) {
 	var i;
 	files = files || [];
 	this.$videos = [];
-
+	
 	this.$videoContainer.empty();
 	this.currentIndex = 0;
-
 	for ( i = 0; i < files.length; i++ ) {
 		filename = files[ i ].filename,
 		url = `https://commons.wikimedia.org/wiki/File:${ filename.split( '/' ).pop()}`,
 		speaker = files[ i ].speaker,
 		total = files.length;
+		console.log(await banana.i18n("si-panel-videos-gallery-attribution",url, speaker, i+1, total));
 		this.$videos.push( $( `
 			<div style="display: none;">
 				<video controls="" muted="" preload="auto" src="${ files[ i ].filename }" width="250" class=""></video>
-				${browser.i18n.getMessage("si_panel_videos_gallery_attribution",[ url, speaker, i+1, total])}
+				${await banana.i18n("si-panel-videos-gallery-attribution",url, speaker, i+1, total)}
 			</div>
 		` ) );
 

--- a/background-script.js
+++ b/background-script.js
@@ -409,6 +409,11 @@ browser.runtime.onMessage.addListener( async function ( message ) {
 	await changeUiLanguage(message.argument);
 	return;
 }
+else if (message.command === "storeParam") {
+	const [name,value] = message.argument;
+	storeParam(name,value);
+	return;
+}
 	message = normalizeMessage(message);
 
 	// When message 'signit.getfiles' is heard, returns relevant extract of records[]
@@ -428,10 +433,6 @@ browser.runtime.onMessage.addListener( async function ( message ) {
 	// When right click's menu "Lingua Libre SignIt" clicked, send message 'signit.sign' to the content script => opens Signit modal
 	else if ( message.command === 'signit.hinticon' ) {
 		callModal(message);
-	}
-	else if (message.command === "storeParam") {
-		storeParam([...message.arguments]);
-		return;
 	}
 });
 

--- a/background-script.js
+++ b/background-script.js
@@ -422,11 +422,10 @@ else if (message.command === "storeParam") {
 		return records[ message.text ] || records[ message.text.toLowerCase() ] || [];
 	}
 	 // When message 'signit.i18nCode' is heard, returns banada object
-	else if ( message.command === 'signit.getfilesb' ) {
-		console.log('bg>signit.getfilesB')
-		// var locale = await getStoredParam( 'uiLanguage' )
-		// loadI18nLocalization(locale);
-		return banana;
+	 else if (message.command === 'bananai18n') {
+		let [msg,placeholderValue] = message.arg;
+		const i18nMessage = banana.i18n(msg,placeholderValue);
+		return i18nMessage;
 	}
 	
 	// Start modal

--- a/content_scripts/signit.js
+++ b/content_scripts/signit.js
@@ -152,11 +152,8 @@
 
 		// Banana test, search `bananaInStore` in files for more
 		console.log("before")
-		var BetterBanana = await browser.storage.local.get( 'bananaInStore' );
-		var messageStore = await browser.storage.local.get( 'sourceMap' ); 
-		console.log("after: BetterBanana = ", BetterBanana.bananaInStore.locale,messageStore.sourceMap)
-
-		content = new SignItCoreContent(BetterBanana.bananaInStore.locale,messageStore.sourceMap);
+		content = new SignItCoreContent();
+		content.init();
 
 		// Setup an absolute-positionned $anchorModal we can programatically move
 		// to be able to point exactly some coords with our popup later

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -18,11 +18,9 @@ var browser = (browserType === 'firefox') ? browser : (browserType === 'chrome')
     }
     _backgroundPage = await getBackgroundPage();
     console.log("Background Page  = ", _backgroundPage);
-		console.log("banana received: ",banana);
 	} else if (browserType === 'firefox') {
 		// Use Firefox WebExtensions API
 		_backgroundPage = await browser.runtime.getBackgroundPage();
-		banana = _backgroundPage.banana;
 	}
 
 	/* *********************************************************** */
@@ -379,13 +377,6 @@ var browser = (browserType === 'firefox') ? browser : (browserType === 'chrome')
 			return;
 		}
 		ui.switchPanel( 'loading' );
-		//banana = _backgroundPage.banana;
-
-		// now in case of the chrome,both popup and modal update, 
-		// but in case of popup you have to off->on again in order to see changes  
-		// and in FF popup UI updates first
-		// in both browsers for the changes to reflect in modal you have to
-		// send another signit.hinticon command in order to see changes
 
 		await sendMessageUp("changeUiLanguage",newLanguage);
 		ui = new UI();

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -50,12 +50,12 @@ var browser = (browserType === 'firefox') ? browser : (browserType === 'chrome')
 	/* *********************************************************** */
 	// Master
 	var UI = function () {
-		document.querySelector('#fetchVideosList').innerHTML = browser.i18n.getMessage('si_addon_preload');
+		document.querySelector('#fetchVideosList').innerHTML = banana.i18n('si-addon-preload');
 
 		// Setup the main tabs
-		this.viewTab = new OO.ui.TabPanelLayout( 'view', { label: browser.i18n.getMessage('si_popup_browse_title') } );
-		this.historyTab = new OO.ui.TabPanelLayout( 'history', { label: browser.i18n.getMessage('si_popup_history_title'), classes: [ 'signit-popup-tab-history' ] } );
-		this.paramTab = new OO.ui.TabPanelLayout( 'param', { label: browser.i18n.getMessage('si_popup_settings_title'), classes: [ 'signit-popup-tab-settings' ] } );
+		this.viewTab = new OO.ui.TabPanelLayout( 'view', { label: banana.i18n('si-popup-browse-title') } );
+		this.historyTab = new OO.ui.TabPanelLayout( 'history', { label: banana.i18n('si-popup-history-title'), classes: [ 'signit-popup-tab-history' ] } );
+		this.paramTab = new OO.ui.TabPanelLayout( 'param', { label: banana.i18n('si-popup-settings-title'), classes: [ 'signit-popup-tab-settings' ] } );
 
 		// Set up the popup page layout
 		this.indexLayout = new OO.ui.IndexLayout( { autoFocus: false, classes: [ 'signit-popup-tabs' ] } );
@@ -83,19 +83,19 @@ var browser = (browserType === 'firefox') ? browser : (browserType === 'chrome')
 	// Browse tab
 	UI.prototype.initView = async function () {
 		// Word input 2 : text field
-		// browser.i18n.getMessage accepts string value as substitutes for placeholders, hence JSON.stringify
-		this.searchWidget = new SearchWidget( { placeholder: browser.i18n.getMessage("si_popup_browse_placeholder", JSON.stringify(Object.keys( _backgroundPage.records ).length) ) } );
+		// banana.i18n accepts string value as substitutes for placeholders, hence JSON.stringify
+		this.searchWidget = new SearchWidget( { placeholder: banana.i18n("si-popup-browse-placeholder", JSON.stringify(Object.keys( _backgroundPage.records ).length) ) } );
 		this.searchWidget.setRecords( _backgroundPage.records );
 		var searchButton = new OO.ui.ButtonWidget( {
 			icon:"search",
-			label: browser.i18n.getMessage("si_popup_browse_label"),
+			label: banana.i18n("si-popup-browse-label"),
 			invisibleLabel: true,
-			title: browser.i18n.getMessage("si_popup_browse_icon")
+			title: banana.i18n("si-popup-browse-icon")
 		} );
 		
 		var searchLayout = new OO.ui.ActionFieldLayout( this.searchWidget, searchButton, {
 			align: 'top',
-			label: browser.i18n.getMessage("si_popup_browse_label"),
+			label: banana.i18n("si-popup-browse-label"),
 			invisibleLabel: true,
 			classes: [ 'signit-popup-tab-browse' ]
 		} );
@@ -116,7 +116,7 @@ var browser = (browserType === 'firefox') ? browser : (browserType === 'chrome')
 		var tabs = await browser.tabs.query({active: true, currentWindow: true});
 		
 		// optimizing message passing for the functions that are present in 
-		// sw.js as well background_script.js
+		// sw.js as well background-script.js
 
 		await sendMessageUp("checkActiveTabInjections",tabs[0].id);
 		var selection = await browser.tabs.sendMessage( tabs[ 0 ].id, {
@@ -135,7 +135,7 @@ var browser = (browserType === 'firefox') ? browser : (browserType === 'chrome')
     if (typeof text !== "string") {
       text = this.searchWidget.getValue();
     }
-    // runs normalize function and wordToFiles in a single go and retruns an array of _word and _files
+    // runs normalize function and wordToFiles in a single go and retruns an array of -word and -files
 
 	const [_word,_files] = await sendMessageUp("normalizeWordAndReturnFiles",text);
     this.coreContent.refresh(_word, _files);
@@ -148,7 +148,7 @@ var browser = (browserType === 'firefox') ? browser : (browserType === 'chrome')
 	// History tab 
 	// .initHistory calls .addHistory which calls .cleanHistory
 	UI.prototype.initHistory = function () {
-		this.$noHistory = $( `<div>${browser.i18n.getMessage("si_popup_history_empty")}</div>` );
+		this.$noHistory = $( `<div>${banana.i18n("si-popup-history-empty")}</div>` );
 		this.history = [];
 		this.$history = [];
 		this.historyTab.$element.append( this.$noHistory );
@@ -213,14 +213,14 @@ var browser = (browserType === 'firefox') ? browser : (browserType === 'chrome')
 		}
 		// Layout
 		signLanguageDropdown = new OO.ui.DropdownWidget( { 
-			label: browser.i18n.getMessage("si_popup_settings_signlanguage-dropdown"), 
+			label: banana.i18n("si-popup-settings-signlanguage-dropdown"), 
 			menu: { items: items }, 
 			$overlay: $( 'body' ) 
 		} );
 		signLanguageLayout = new OO.ui.FieldLayout( signLanguageDropdown, {
-			label: browser.i18n.getMessage("si_popup_settings_signlanguage"),
+			label: banana.i18n("si-popup-settings-signlanguage"),
 			align: 'top',
-			help: browser.i18n.getMessage("si_popup_settings_signlanguage-help"),
+			help: banana.i18n("si-popup-settings-signlanguage-help"),
 			//helpInline: true
 		} );
 		
@@ -240,14 +240,14 @@ var browser = (browserType === 'firefox') ? browser : (browserType === 'chrome')
 		}
 		// Layout
 		uiLanguageDropdown = new OO.ui.DropdownWidget({ 
-			label: browser.i18n.getMessage("si_popup-settings_signlanguage"), 
+			label: banana.i18n("si-popup-settings-signlanguage"), 
 			menu: { items: items }, 
 			$overlay: $( 'body' ) 
 		} );
 		uiLanguageLayout = new OO.ui.FieldLayout( uiLanguageDropdown, {
-			label: browser.i18n.getMessage("si_popup_settings_uilanguage"),
+			label: banana.i18n("si-popup-settings-uilanguage"),
 			align: 'top',
-			help: browser.i18n.getMessage("si_popup_settings_uilanguage-help"),
+			help: banana.i18n("si-popup-settings-uilanguage-help"),
 			//helpInline: true
 		} );
 
@@ -257,9 +257,9 @@ var browser = (browserType === 'firefox') ? browser : (browserType === 'chrome')
 			min: 0
 		} );
 		historyLayout = new OO.ui.FieldLayout( historyWidget, {
-			label: browser.i18n.getMessage("si_popup_settings_history"),
+			label: banana.i18n("si-popup-settings-history"),
 			align: 'top',
-			help: browser.i18n.getMessage("si_popup_settings_history_help"),
+			help: banana.i18n("si-popup-settings-history-help"),
 		} );
 
 		
@@ -269,7 +269,7 @@ var browser = (browserType === 'firefox') ? browser : (browserType === 'chrome')
 			selected: _backgroundPage.params.wpintegration,
 		} );
 		wpintegrationLayout = new OO.ui.FieldLayout( wpintegrationWidget, {
-			label: browser.i18n.getMessage("si_popup_settings_wpintegration"),
+			label: banana.i18n("si-popup-settings-wpintegration"),
 			align: 'inline',
 		} );
 
@@ -278,7 +278,7 @@ var browser = (browserType === 'firefox') ? browser : (browserType === 'chrome')
 			selected: _backgroundPage.params.twospeed,
 		} );
 		twospeedLayout = new OO.ui.FieldLayout( twospeedWidget, {
-			label: browser.i18n.getMessage("si_popup_settings_twospeed"),
+			label: banana.i18n("si-popup-settings-twospeed"),
 			align: 'inline',
 		} );
 		// Hint icon shortcut
@@ -286,7 +286,7 @@ var browser = (browserType === 'firefox') ? browser : (browserType === 'chrome')
       selected: _backgroundPage.params.hinticon,
     });
     hinticonLayout = new OO.ui.FieldLayout(hinticonWidget, {
-      label: browser.i18n.getMessage('si_popup_settings_hint-icon'),
+      label: banana.i18n('si-popup-settings-hint-icon'),
       align: 'inline',
     });
     // Colored text
@@ -294,29 +294,29 @@ var browser = (browserType === 'firefox') ? browser : (browserType === 'chrome')
       selected: _backgroundPage.params.coloredwords,
     });
     coloredwordsLayout = new OO.ui.FieldLayout(coloredwordsWidget, {
-      label: browser.i18n.getMessage('si_popup_settings_enlighten'),
+      label: banana.i18n('si-popup-settings-enlighten'),
       align: 'inline',
     });
 
 		// Choose panels : both, definition, video
 		var panelsOption0 = new OO.ui.ButtonOptionWidget( {
 			data: 'definition',
-			label: browser.i18n.getMessage("si_popup_settings_choosepanels_definition")
+			label: banana.i18n("si-popup-settings-choosepanels-definition")
 		} ),
 		panelsOption1 = new OO.ui.ButtonOptionWidget( {
 			data: 'both',
-			label: browser.i18n.getMessage("si_popup_settings_choosepanels_both")
+			label: banana.i18n("si-popup-settings-choosepanels-both")
 		} );
 		panelsOption2 = new OO.ui.ButtonOptionWidget( {
 			data: 'video',
-			label:  browser.i18n.getMessage("si_popup_settings_choosepanels_video")
+			label:  banana.i18n("si-popup-settings-choosepanels-video")
 		} );
 		choosepanelsWidget = new OO.ui.ButtonSelectWidget( {
 			items: [ panelsOption0, panelsOption1, panelsOption2 ]
 		} );
 		// Layout
 		choosepanelsLayout = new OO.ui.FieldLayout( choosepanelsWidget, {
-			label:  browser.i18n.getMessage("si_popup_settings_choosepanels"),
+			label:  banana.i18n("si-popup-settings-choosepanels"),
 			align: 'top',
 		} );
 

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -87,10 +87,9 @@ var browser = (browserType === 'firefox') ? browser : (browserType === 'chrome')
 		} );
 
 		// Add the CoreContent view
-		// similar to what we did in signit.js since here banana is defined solely as per i18n functionality 
-		var BetterBanana = await browser.storage.local.get( 'bananaInStore' ); 
-		var messageStore = await browser.storage.local.get( 'sourceMap' ); 
-		this.coreContent = new SignItCoreContent(BetterBanana.bananaInStore.locale,messageStore.sourceMap);
+
+		this.coreContent = new SignItCoreContent();
+		this.coreContent.init();
 		this.coreContent.getContainer().hide();
 
 		// Put all that in the tab

--- a/sw.js
+++ b/sw.js
@@ -736,7 +736,8 @@ async function setState(value) {
       checkActiveTabInjections(message.argument);
     }
     else if (message.command === "storeParam") {
-      storeParam([...message.argument]);
+      const [name,value] = message.argument;
+      storeParam(name,value);
     }
     else if (message.command === "changeUiLanguage") {
       await changeUiLanguage(message.argument);

--- a/sw.js
+++ b/sw.js
@@ -719,7 +719,7 @@ async function setState(value) {
     // When message 'signit.i18nCode' is heard, returns banada object
     else if (message.command === 'bananai18n') {
       let [msg,placeholderValue] = message.arg;
-      const i18nMessage = banana.i18n(msg,placeholderValue);
+      const i18nMessage = banana.i18n(msg,...placeholderValue);
       sendResponse(i18nMessage);
     }
 

--- a/sw.js
+++ b/sw.js
@@ -717,14 +717,10 @@ async function setState(value) {
       sendResponse(records[message.text] || records[message.text.toLowerCase()] || []);
     }
     // When message 'signit.i18nCode' is heard, returns banada object
-    else if (
-      message.command === "signit.getfilesb" ||
-      message.command === "getBanana"
-    ) {
-      console.log("bg>signit.getfilesB");
-      // What this does is it accesses the messageStore inside banana amd spreads the sourecMap
-      // which is an instanceof Map thereby converting it into an array. This is later recreated inside popup
-      sendResponse([[...banana.messageStore.sourceMap], banana.locale]);
+    else if (message.command === 'bananai18n') {
+      let [msg,placeholderValue] = message.arg;
+      const i18nMessage = banana.i18n(msg,placeholderValue);
+      sendResponse(i18nMessage);
     }
 
     // Start modal

--- a/sw.js
+++ b/sw.js
@@ -438,9 +438,6 @@ async function setState(value) {
 
     // Declare localisation
     banana.setLocale(locale); // Change to new locale
-    storeParam("bananaInStore", banana);
-    storeParam("sourceMap", Array.from(banana.messageStore.sourceMap));
-
     // state = "ready";
     state = await setState("ready");
 


### PR DESCRIPTION
## Changes Made

### June 13
  - [refactor : storeParams now working properly](https://github.com/lingua-libre/SignIt/commit/6304977f2f020fbf4f7f5c09ad80431a03d68b44) - Used array destructuring to fetch the arguments properly. With this `storeParam` message now works properly and invokes the `storeParam` function inside `sw.js` and `background-script.js` . 
  I think this addresses #87 . Although #56 still persists.
  - [chore: passing message to execute i18n natively inside sw/bg.js](https://github.com/lingua-libre/SignIt/commit/94aaa8d7df34bf4ace617acf987f1e563ecdd18d) - This is the **highlight of this PR**. I figured it was better to pass messages from popup/other content scripts to execute `banana.i18n` directly inside `sw.js/background-script.js` and then send the response acccordingly.
   Pros and cons of what we were doing earlier vs now :
    - ### EARLIER [EDIT: Chrome native's `browser.i18n` API]
      - **Pros** :
        - It worked as expected and wasn't too asynchronous in nature, relied on local storage in the name of asynchronous nature.
      - **Cons** : 
        - **Verbosity changed depending on the context of usage :** For example - [SignItVideosGallery](https://github.com/lingua-libre/SignIt/blob/63d6c055cbb590afa6661d895a5d0a4704810b2c/SignItVideosGallery.js#L24C2-L37C5) and [SignItCoreContent](https://github.com/lingua-libre/SignIt/blob/63d6c055cbb590afa6661d895a5d0a4704810b2c/SignItCoreContent.js#L2C3-L3C58). In both the files different implementations of the same functions exist.
        - **Repetitve in nature :** If some other content script or constructor function popped , we'd have to copy/paste it again in order to make it work.
        - **Buggy UI :** While changing UI language , Popup had to be toggled off/on in order to see the changes and similar  had to be done for the modal. This might have been due to `SignItCoreContent` constructor not initializing timely , rather than a local storage issue. Although I am not sure why this occured as upon being passed with chosen arguements (user's preferred language ), it was logged correctly but rendered previous language.
    - ### NOW [EDIT: Wikimedia `banana.i18n` sent up and processed in sw.js/background.js]
      - **Pros** :
        - **Authenticity:** leverages the original library , hence maintaining the authenticity.
        - **Message passing:** only needs a message to execute.
        - **Little to no verbosity:** Unlike our own i18n , this works the same in all the contexts and we dont have to redefine it as per our preference every time.
       - **Cons** :
         - **Requires an async environment:** As we are passing messages , we are returned with a promise which needs to be resolved whenever the function is called. This can become problematic when working with constructors. This is dealt with in [fix : implemented the same message passing functionality as in popup](https://github.com/lingua-libre/SignIt/commit/d33217a0b37c7fa1ff8c4d543c10bcd159c333b7) by using an async prototype function named `init`, although not the best workaround.
         - **Irregualar html parsing:** While the library `banana.i18n` addresses its own , if not added as html inside the script, will render the string as is.
         

With this #84 can be closed now.
         
- [reverting to banana.i18n](https://github.com/lingua-libre/SignIt/commit/569136841b36e2536419b1c3b3008d7b348a645f) - Since we are now using `banana.i18n` , replacing `browser.i18n` API as well as its messages.
- [fix : implemented the same message passing functionality as in popup](https://github.com/lingua-libre/SignIt/commit/d33217a0b37c7fa1ff8c4d543c10bcd159c333b7) - This tries to achieve the same , but since its a constructor , promises had to be resolved first inside an async prototype, then inserted separately inside it using jQuery DOM manipulation. The only issue is that whenever it is called `init` has to be invoked as shown in [refactor : updated how SignItCoreContent() is called](https://github.com/lingua-libre/SignIt/commit/53c6bacad833143170757d9d0cd9c427a05c5244).
- [refactor: implemented the same message passing i18n functionality](https://github.com/lingua-libre/SignIt/commit/4407699ea6feaa2c7e28eac45063428065256944) - Same thing as earlier.

### June 14

- [refactor: used HTML instead of text for videosPanelNoVideoEmpty](https://github.com/lingua-libre/SignIt/commit/9dfaa56cf16e40c2022caeb48b511cc03ac1098f) - As mentioned above in the cons, earlier when used `.text()` , rendered `<br/>` as is. But replacing it with `.html()` resolved it.
- [storing banana and sourceMap no longer needed](https://github.com/lingua-libre/SignIt/commit/5793669e1cf260396872ee69fbe60938fdded2f0) - we don't need to store this inside `loadi18Localization` now as we no longer rely on it.
  