### PR TITLE
Update message as per `banana.i18n`

### DIFF
--- a/_locales/anp/messages.json
+++ b/_locales/anp/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "<a href='$1' target='_blank'>$2</a> द्वारा – $4 मँ सँ $3 नंबरिया वीडियो",
+    "message": "{{link:$1|$2}} द्वारा – $4 मँ सँ $3 नंबरिया वीडियो",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/az/messages.json
+++ b/_locales/az/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "<a href='$1' target='_blank'>$2</a> – Video $3/$4",
+    "message": "{{link:$1|$2}} – Video $3/$4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/blk/messages.json
+++ b/_locales/blk/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "<a href='$1' target='_blank'>$2</a>တွမ်ႏ – ဗီဒီယို $3 ယို $4",
+    "message": "{{link:$1|$2}}တွမ်ႏ – ဗီဒီယို $3 ယို $4",
     "description": ""
   },
   "si_panel_videos_contribute_label": {

--- a/_locales/bn/messages.json
+++ b/_locales/bn/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "<a href='$1' target='_blank'>$2</a> দ্বারা – $4 এর মধ্যে $3 নং ভিডিও",
+    "message": "{{link:$1|$2}} দ্বারা – $4 এর মধ্যে $3 নং ভিডিও",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/br/messages.json
+++ b/_locales/br/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "gant <a href='$1' target='_blank'>$2</a> – $3 eus $4 video",
+    "message": "gant {{link:$1|$2}} – $3 eus $4 video",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/ce/messages.json
+++ b/_locales/ce/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "авторалла: <a href='$1' target='_blank'>$2</a> – $3 видео $4 чохь",
+    "message": "авторалла: {{link:$1|$2}} – $3 видео $4 чохь",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "von <a href='$1' target='_blank'>$2</a> – Video $3 von $4",
+    "message": "von {{link:$1|$2}} – Video $3 von $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/diq/messages.json
+++ b/_locales/diq/messages.json
@@ -8,7 +8,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "Be <a href='$1' target='_blank'>$2</a> ra – Video $3 yê $4",
+    "message": "Be {{link:$1|$2}} ra – Video $3 yê $4",
     "description": ""
   },
   "si_panel_definitions_title": {

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "by <a href='$1' target='_blank'>$2</a> – Video $3 of $4",
+    "message": "by {{link:$1|$2}} – Video $3 of $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "por <a href='$1' target='_blank'>$2</a> – Video $3 de $4",
+    "message": "por {{link:$1|$2}} – Video $3 de $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/fa/messages.json
+++ b/_locales/fa/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "توسط <a href='$1' target='_blank'>$2</a> – ویدئو $3 از میان $4",
+    "message": "توسط {{link:$1|$2}} – ویدئو $3 از میان $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/fi/messages.json
+++ b/_locales/fi/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "tekijä: <a href='$1' target='_blank'>$2</a> – video $3 / $4",
+    "message": "tekijä: {{link:$1|$2}} – video $3 / $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "par <a href='$1' target='_blank'>$2</a> – Vidéo $3 sur $4",
+    "message": "par {{link:$1|$2}} – Vidéo $3 sur $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/gl/messages.json
+++ b/_locales/gl/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "por <a href='$1' target='_blank'>$2</a> – Vídeo $3 de $4",
+    "message": "por {{link:$1|$2}} – Vídeo $3 de $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/he/messages.json
+++ b/_locales/he/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "מאת <a href='$1' target='_blank'>$2</a> – סרט $3 מתוך $4",
+    "message": "מאת {{link:$1|$2}} – סרט $3 מתוך $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/hi/messages.json
+++ b/_locales/hi/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "<a href='$1' target='_blank'>$2</a> द्वारा – $4 में से $3 नंबरी वीडियो",
+    "message": "{{link:$1|$2}} द्वारा – $4 में से $3 नंबरी वीडियो",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/hy/messages.json
+++ b/_locales/hy/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "հեղինակ՝ <a href='$1' target='_blank'>$2</a> – տեսանյութ $3 $4-ից",
+    "message": "հեղինակ՝ {{link:$1|$2}} – տեսանյութ $3 $4-ից",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/ia/messages.json
+++ b/_locales/ia/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "per <a href='$1' target='_blank'>$2</a> – Video $3 de $4",
+    "message": "per {{link:$1|$2}} – Video $3 de $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/id/messages.json
+++ b/_locales/id/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "oleh <a href='$1' target='_blank'>$2</a> – Video $3 dari $4",
+    "message": "oleh {{link:$1|$2}} – Video $3 dari $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "di <a href='$1' target='_blank'>$2</a> - Video $3 di $4",
+    "message": "di {{link:$1|$2}} - Video $3 di $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "<a href='$1' target='_blank'>$2</a>に帰属  – 動画 $4件中の$3件目",
+    "message": "{{link:$1|$2}}に帰属  – 動画 $4件中の$3件目",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/kk-cyrl/messages.json
+++ b/_locales/kk-cyrl/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "ауторы: <a href='$1' target='_blank'>$2</a> — $3/$4 видео",
+    "message": "ауторы: {{link:$1|$2}} — $3/$4 видео",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "만든이: <a href='$1' target='_blank'>$2</a> – 동영상 $3 / $4",
+    "message": "만든이: {{link:$1|$2}} – 동영상 $3 / $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/krc/messages.json
+++ b/_locales/krc/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "<a href='$1' target='_blank'>$2</a> – Видео $3/$4",
+    "message": "{{link:$1|$2}} – Видео $3/$4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/lmo/messages.json
+++ b/_locales/lmo/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "de <a href='$1' target='_blank'>$2</a> - Video $3 de $4",
+    "message": "de {{link:$1|$2}} - Video $3 de $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/mk/messages.json
+++ b/_locales/mk/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "од <a href='$1' target='_blank'>$2</a> — Видео $3 од $4",
+    "message": "од {{link:$1|$2}} — Видео $3 од $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/ms/messages.json
+++ b/_locales/ms/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "karya <a href='$1' target='_blank'>$2</a> – Video $3 dari $4",
+    "message": "karya {{link:$1|$2}} – Video $3 dari $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/nb/messages.json
+++ b/_locales/nb/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "av <a href='$1' target='_blank'>$2</a> – video $3 av $4",
+    "message": "av {{link:$1|$2}} – video $3 av $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/pt-br/messages.json
+++ b/_locales/pt-br/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "por <a href='$1' target='_blank'>$2</a> – Vídeo $3 de $4",
+    "message": "por {{link:$1|$2}} – Vídeo $3 de $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/pt/messages.json
+++ b/_locales/pt/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "de <a href='$1' target='_blank'>$2</a> – Vídeo $3 de $4",
+    "message": "de {{link:$1|$2}} – Vídeo $3 de $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "авторство: <a href='$1' target='_blank'>$2</a> – видео $3 в $4",
+    "message": "авторство: {{link:$1|$2}} – видео $3 в $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/scn/messages.json
+++ b/_locales/scn/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "di <a href='$1' target='_blank'>$2</a> – Vìdiu $3 di $4",
+    "message": "di {{link:$1|$2}} – Vìdiu $3 di $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/sl/messages.json
+++ b/_locales/sl/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "avtor <a href='$1' target='_blank'>$2</a> – video $3 od $4",
+    "message": "avtor {{link:$1|$2}} – video $3 od $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/sv/messages.json
+++ b/_locales/sv/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "av <a href='$1' target='_blank'>$2</a> – Video $3 av $4",
+    "message": "av {{link:$1|$2}} – Video $3 av $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/te/messages.json
+++ b/_locales/te/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "కర్త: <a href='$1' target='_blank'>$2</a> – $4 వీడియోల్లో $3 వది",
+    "message": "కర్త: {{link:$1|$2}} – $4 వీడియోల్లో $3 వది",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/tl/messages.json
+++ b/_locales/tl/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "ni <a href='$1' target='_blank'>$2</a> - Video $3 ng $4",
+    "message": "ni {{link:$1|$2}} - Video $3 ng $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/tr/messages.json
+++ b/_locales/tr/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "<a href='$1' target='_blank'>$2</a> – Video $3/$4",
+    "message": "{{link:$1|$2}} – Video $3/$4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/uk/messages.json
+++ b/_locales/uk/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "від <a href='$1' target='_blank'>$2</a> – Відео $3 із $4",
+    "message": "від {{link:$1|$2}} – Відео $3 із $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/ur/messages.json
+++ b/_locales/ur/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "<a href='$1' target='_blank'>$2</a> $4 توں ویڈیو $3 بݨائی اے",
+    "message": "{{link:$1|$2}} $4 توں ویڈیو $3 بݨائی اے",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/zh-hans/messages.json
+++ b/_locales/zh-hans/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "贡献者 <a href='$1' target='_blank'>$2</a> – 视频 $3 / $4",
+    "message": "贡献者 {{link:$1|$2}} – 视频 $3 / $4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/_locales/zh-hant/messages.json
+++ b/_locales/zh-hant/messages.json
@@ -12,7 +12,7 @@
     "description": ""
   },
   "si_panel_videos_gallery_attribution": {
-    "message": "貢獻者：<a href='$1' target='_blank'>$2</a> – 影片$3/$4",
+    "message": "貢獻者：{{link:$1|$2}} – 影片$3/$4",
     "description": ""
   },
   "si_panel_videos_empty": {

--- a/i18n/anp.json
+++ b/i18n/anp.json
@@ -8,7 +8,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Lingua Libre प उपलब्ध सब्भे वीडियो क सूची प्राप्त होय रहलौ छौं।",
 	"si-panel-videos-title": "मीडिया:",
-	"si-panel-videos-gallery-attribution": "<a href='$1' target='_blank'>$2</a> द्वारा – $4 मँ सँ $3 नंबरिया वीडियो",
+	"si-panel-videos-gallery-attribution": "{{link:$1|$2}} द्वारा – $4 मँ सँ $3 नंबरिया वीडियो",
 	"si-panel-videos-empty": "हैय शब्द क एखनी तलक रिकॉर्ड नाय करलौ गेलौ छौं,<br>किंतु SignIt, लोगौ सिनी द्वारा बनैलौ गेलौ एगो परियोजना छेकै, आरो तोंय एकरा मँ योगदान करै सकै छौ।",
 	"si-panel-videos-contribute-label": "सांकेतिक भाषा प योगदान करौ",
 	"si-panel-definitions-title": "परिभाषा:",

--- a/i18n/az.json
+++ b/i18n/az.json
@@ -8,7 +8,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Lingua Libre-də mövcud olan bütün videoların siyahısı gətirilir.",
 	"si-panel-videos-title": "Media:",
-	"si-panel-videos-gallery-attribution": "<a href='$1' target='_blank'>$2</a> – Video $3/$4",
+	"si-panel-videos-gallery-attribution": "{{link:$1|$2}} – Video $3/$4",
 	"si-panel-videos-empty": "Bu söz hələ qeydə alınmayıb,<br> lakin SignIt icma əsaslı layihədir, siz ona töhfə verə bilərsiniz.",
 	"si-panel-videos-contribute-label": "İşarə dili ilə töhfə verin",
 	"si-panel-definitions-title": "Təriflər:",

--- a/i18n/blk.json
+++ b/i18n/blk.json
@@ -7,7 +7,7 @@
 	"si-addon-title": "လိင်းကွာလီဗာရယ်ကို တဲမ်းသွော့ꩻစူမုဲင်",
 	"si-addon-preload": "Lingua Libreအကို ကလꩻနွောင်ꩻဒါႏ ထူႏလꩻ ဗီဒီယိုဖုံႏ ကားကအဝ်ႏယိုလိတ်ထွိုင်။",
 	"si-panel-videos-title": "မီဒီယာ:",
-	"si-panel-videos-gallery-attribution": "<a href='$1' target='_blank'>$2</a>တွမ်ႏ – ဗီဒီယို $3 ယို $4",
+	"si-panel-videos-gallery-attribution": "{{link:$1|$2}}တွမ်ႏ – ဗီဒီယို $3 ယို $4",
 	"si-panel-videos-contribute-label": "နွို့စွဲးကမ်းငီꩻသွော့ꩻတွမ်ႏဘာႏသာႏငဝ်းငွါစူမုဲင်",
 	"si-panel-definitions-title": "အဓိပ္ပာယ်ႏဗွောင်နယ်ဆင်ႏ:",
 	"si-panel-definitions-wikt-iso": "အေင်ႏကလေတ်",

--- a/i18n/bn.json
+++ b/i18n/bn.json
@@ -8,7 +8,7 @@
 	"si-addon-title": "লিঙ্গুয়া লিব্রে সাইনইট",
 	"si-addon-preload": "Lingua Libre-এ উপলব্ধ সমস্ত ভিডিওর তালিকা আনা হচ্ছে।",
 	"si-panel-videos-title": "মিডিয়া:",
-	"si-panel-videos-gallery-attribution": "<a href='$1' target='_blank'>$2</a> দ্বারা – $4 এর মধ্যে $3 নং ভিডিও",
+	"si-panel-videos-gallery-attribution": "{{link:$1|$2}} দ্বারা – $4 এর মধ্যে $3 নং ভিডিও",
 	"si-panel-videos-empty": "এই শব্দটি এখনও রেকর্ড করা হয়নি,<br>তবে SignIt একটি ক্রাউড সোর্স প্রকল্প, আপনি এতে অবদান রাখতে পারেন।",
 	"si-panel-videos-contribute-label": "ইশারা ভাষার মাধ্যমে অবদান রাখুন",
 	"si-panel-definitions-title": "সংজ্ঞা:",

--- a/i18n/br.json
+++ b/i18n/br.json
@@ -7,7 +7,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "O kargañ ar videoioù da gaout war Ligua Libre.",
 	"si-panel-videos-title": "Media:",
-	"si-panel-videos-gallery-attribution": "gant <a href='$1' target='_blank'>$2</a> – $3 eus $4 video",
+	"si-panel-videos-gallery-attribution": "gant {{link:$1|$2}} – $3 eus $4 video",
 	"si-panel-videos-empty": "N'eo bet bet enrollet ar ger-se c'hoazh,<br>SignIt zo ur raktres kenlabourat avat ha gallout 'rit degas ho lod ivez.",
 	"si-panel-videos-contribute-label": "Kendeurel gant yezh ar sinoù",
 	"si-panel-definitions-title": "Termenadurioù:",

--- a/i18n/ce.json
+++ b/i18n/ce.json
@@ -7,7 +7,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Lingua Libre тӀехь йолу йерриге видео могӀам гойту.",
 	"si-panel-videos-title": "Медиа:",
-	"si-panel-videos-gallery-attribution": "авторалла: <a href='$1' target='_blank'>$2</a> – $3 видео $4 чохь",
+	"si-panel-videos-gallery-attribution": "авторалла: {{link:$1|$2}} – $3 видео $4 чохь",
 	"si-panel-videos-empty": "И дош хӀинца а дӀайаздина дац,<br> делахь SignIt — краудсорсинган проект йу, цундела ахьа къахьега мега!",
 	"si-panel-definitions-title": "Билгалдалар:",
 	"si-panel-definitions-wikt-iso": "en",

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -8,7 +8,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Abruf der Liste aller auf Lingua Libre verfügbaren Videos.",
 	"si-panel-videos-title": "Medien:",
-	"si-panel-videos-gallery-attribution": "von <a href='$1' target='_blank'>$2</a> – Video $3 von $4",
+	"si-panel-videos-gallery-attribution": "von {{link:$1|$2}} – Video $3 von $4",
 	"si-panel-videos-empty": "Dieses Wort wurde noch nicht aufgenommen,<br>aber SignIt ist ein Crowd-Sourced-Projekt, zu dem du beitragen kannst.",
 	"si-panel-videos-contribute-label": "Mit Gebärdensprache beitragen",
 	"si-panel-definitions-title": "Definitionen:",

--- a/i18n/diq.json
+++ b/i18n/diq.json
@@ -6,7 +6,7 @@
 	},
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-panel-videos-title": "Medya:",
-	"si-panel-videos-gallery-attribution": "Be <a href='$1' target='_blank'>$2</a> ra – Video $3 yê $4",
+	"si-panel-videos-gallery-attribution": "Be {{link:$1|$2}} ra – Video $3 yê $4",
 	"si-panel-definitions-title": "Şınasiye:",
 	"si-panel-definitions-wikt-pointer": "Wikiqısebend dı bıvin",
 	"si-panel-definitions-empty": "Sınasnayış nëvineya",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -9,7 +9,7 @@
 	"si-addon-preload": "Fetching the list of all videos available on Lingua Libre.",
 
 	"si-panel-videos-title":"Media:",
-	"si-panel-videos-gallery-attribution": "by <a href='$1' target='_blank'>$2</a> – Video $3 of $4",
+	"si-panel-videos-gallery-attribution": "by {{link:$1|$2}} – Video $3 of $4",
 	"si-panel-videos-empty":"This word hasn't been recorded yet,<br>but SignIt is crowd sourced project, you can contribute to it.",
 	"si-panel-videos-contribute-label":"Contribute with Sign Language",
 

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -8,7 +8,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Obteniendo la lista de todos los videos disponibles en Lingua Libre.",
 	"si-panel-videos-title": "Vídeo o audio:",
-	"si-panel-videos-gallery-attribution": "por <a href='$1' target='_blank'>$2</a> – Video $3 de $4",
+	"si-panel-videos-gallery-attribution": "por {{link:$1|$2}} – Video $3 de $4",
 	"si-panel-videos-empty": "Esta palabra aún no ha sido grabada,<br> pero SignIt es un proyecto colaborativo, ¡puedes contribuir a él!",
 	"si-panel-videos-contribute-label": "Contribuye con Lengua de señas",
 	"si-panel-definitions-title": "Definiciones:",

--- a/i18n/fa.json
+++ b/i18n/fa.json
@@ -8,7 +8,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "در حال واکشی لیست همهٔ ویدیوهای موجود در Lingua Libre.",
 	"si-panel-videos-title": "رسانه:",
-	"si-panel-videos-gallery-attribution": "توسط <a href='$1' target='_blank'>$2</a> – ویدئو $3 از میان $4",
+	"si-panel-videos-gallery-attribution": "توسط {{link:$1|$2}} – ویدئو $3 از میان $4",
 	"si-panel-videos-empty": "این کلمه هنوز ثبت نشده است،<br>اما SignIt یک پروژهٔ جمعی است، می‌توانید در آن مشارکت کنید.",
 	"si-panel-videos-contribute-label": "با زبان اشاره همکاری کنید",
 	"si-panel-definitions-title": "تعاریف:",

--- a/i18n/fi.json
+++ b/i18n/fi.json
@@ -8,7 +8,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Haetaan luetteloa kaikista Lingua Libressä saatavilla olevista videoista.",
 	"si-panel-videos-title": "Media:",
-	"si-panel-videos-gallery-attribution": "tekijä: <a href='$1' target='_blank'>$2</a> – video $3 / $4",
+	"si-panel-videos-gallery-attribution": "tekijä: {{link:$1|$2}} – video $3 / $4",
 	"si-panel-videos-empty": "Tätä sanaa ei ole vielä tallennettu,<br> mutta SignIt on joukkolähdeprojekti, voit osallistua siihen.",
 	"si-panel-videos-contribute-label": "Osallistu viittomakielellä",
 	"si-panel-definitions-title": "Määritelmät:",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -11,7 +11,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Chargement des vidéos disponibles sur Lingua Libre.",
 	"si-panel-videos-title": "Média :",
-	"si-panel-videos-gallery-attribution": "par <a href='$1' target='_blank'>$2</a> – Vidéo $3 sur $4",
+	"si-panel-videos-gallery-attribution": "par {{link:$1|$2}} – Vidéo $3 sur $4",
 	"si-panel-videos-empty": "Ce mot n’a pas encore été enregistré<br/> mais SignIt est un projet participatif auquel vous pouvez prendre part.",
 	"si-panel-videos-contribute-label": "Contribuer en langue des signes",
 	"si-panel-definitions-title": "Définitions :",

--- a/i18n/gl.json
+++ b/i18n/gl.json
@@ -7,7 +7,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Buscando a lista de todos os vídeos dispoñibles en Lingua Libre.",
 	"si-panel-videos-title": "Multimedia:",
-	"si-panel-videos-gallery-attribution": "por <a href='$1' target='_blank'>$2</a> – Vídeo $3 de $4",
+	"si-panel-videos-gallery-attribution": "por {{link:$1|$2}} – Vídeo $3 de $4",
 	"si-panel-videos-empty": "Aínda non se gravou esta palabra,<br>pero SignIt é un proxecto colaborativo e podes contribuír a el.",
 	"si-panel-videos-contribute-label": "Contribuír en lingua de sinais",
 	"si-panel-definitions-title": "Definicións:",

--- a/i18n/he.json
+++ b/i18n/he.json
@@ -8,7 +8,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "אחזור רשימת כל הסרטים הזמינים בלינגווה ליברה.",
 	"si-panel-videos-title": "מדיה:",
-	"si-panel-videos-gallery-attribution": "מאת <a href='$1' target='_blank'>$2</a> – סרט $3 מתוך $4",
+	"si-panel-videos-gallery-attribution": "מאת {{link:$1|$2}} – סרט $3 מתוך $4",
 	"si-panel-videos-empty": "המילה הזאת עוד לא הוקלטה,<br>אבל SignIt הוא מיזם במיקור המונים, אז יש לך הזדמנות לתרום לו.",
 	"si-panel-videos-contribute-label": "תרומה בשפת סימנים",
 	"si-panel-definitions-title": "הגדרות:",

--- a/i18n/hi.json
+++ b/i18n/hi.json
@@ -9,7 +9,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Lingua Libre पर उपलब्ध सभी वीडियों की सूची प्राप्त की जा रही है।",
 	"si-panel-videos-title": "मीडिया:",
-	"si-panel-videos-gallery-attribution": "<a href='$1' target='_blank'>$2</a> द्वारा – $4 में से $3 नंबरी वीडियो",
+	"si-panel-videos-gallery-attribution": "{{link:$1|$2}} द्वारा – $4 में से $3 नंबरी वीडियो",
 	"si-panel-videos-empty": "इस शब्द को अभी तक रिकॉर्ड नहीं किया गया है,<br>मगर SignIt, लोगों द्वारा बनाई गई एक परियोजना है, और आप इसमें योगदान कर सकते हैं।",
 	"si-panel-videos-contribute-label": "सांकेतिक भाषा पर योगदान करें",
 	"si-panel-definitions-title": "परिभाषाएँ:",

--- a/i18n/hy.json
+++ b/i18n/hy.json
@@ -9,7 +9,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Տալիս է Lingua Libre-ում հասանելի բոլոր տեսանյութերի ցուցակը:",
 	"si-panel-videos-title": "Մեդիա․",
-	"si-panel-videos-gallery-attribution": "հեղինակ՝ <a href='$1' target='_blank'>$2</a> – տեսանյութ $3 $4-ից",
+	"si-panel-videos-gallery-attribution": "հեղինակ՝ {{link:$1|$2}} – տեսանյութ $3 $4-ից",
 	"si-panel-videos-empty": "Այս բառը դեռ ձայնագրված չէ,<br> բայց SignIt-ը քրաուդսորսինգային նախագիծ է, և դուք կարող եք ներդնել ձեր ավանդը:",
 	"si-panel-videos-contribute-label": "Ներդրեք ձեր ավանդը ժեստերի լեզվով",
 	"si-panel-definitions-title": "Սահմանումներ․",

--- a/i18n/ia.json
+++ b/i18n/ia.json
@@ -7,7 +7,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Obtenente le lista de tote le videos disponibile sur Lingua Libre.",
 	"si-panel-videos-title": "Multimedia:",
-	"si-panel-videos-gallery-attribution": "per <a href='$1' target='_blank'>$2</a> – Video $3 de $4",
+	"si-panel-videos-gallery-attribution": "per {{link:$1|$2}} – Video $3 de $4",
 	"si-panel-videos-empty": "Iste parola non ha ancora essite registrate,<br>ma SignIt es un projecto participative al qual tu pote contribuer.",
 	"si-panel-videos-contribute-label": "Contribuer con linguage de signos",
 	"si-panel-definitions-title": "Definitiones:",

--- a/i18n/id.json
+++ b/i18n/id.json
@@ -10,7 +10,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Mengambil daftar semua video yang tersedia di Lingua Libre.",
 	"si-panel-videos-title": "Media:",
-	"si-panel-videos-gallery-attribution": "oleh <a href='$1' target='_blank'>$2</a> – Video $3 dari $4",
+	"si-panel-videos-gallery-attribution": "oleh {{link:$1|$2}} – Video $3 dari $4",
 	"si-panel-videos-empty": "Kata ini belum direkam,<br>tetapi karena SignIt adalah proyek urun daya, Anda dapat ikut berkontribusi.",
 	"si-panel-videos-contribute-label": "Berkontribusi dengan Bahasa Isyarat",
 	"si-panel-definitions-title": "Definisi:",

--- a/i18n/it.json
+++ b/i18n/it.json
@@ -10,7 +10,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Recupero l'elenco di tutti i video disponibili su Lingua Libre.",
 	"si-panel-videos-title": "Media:",
-	"si-panel-videos-gallery-attribution": "di <a href='$1' target='_blank'>$2</a> - Video $3 di $4",
+	"si-panel-videos-gallery-attribution": "di {{link:$1|$2}} - Video $3 di $4",
 	"si-panel-videos-empty": "Questa parola non è stata ancora registrata,<br>ma SignIt è un progetto in crowdsourcing, puoi contribuire anche tu.",
 	"si-panel-videos-contribute-label": "Contribuisci con la lingua dei segni",
 	"si-panel-definitions-title": "Definizioni:",

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -14,7 +14,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Lingua Libreの利用可能なすべての動画のリストを取得しています。",
 	"si-panel-videos-title": "メディア:",
-	"si-panel-videos-gallery-attribution": "<a href='$1' target='_blank'>$2</a>に帰属  – 動画 $4件中の$3件目",
+	"si-panel-videos-gallery-attribution": "{{link:$1|$2}}に帰属  – 動画 $4件中の$3件目",
 	"si-panel-videos-empty": "この言葉はまだ記録されていません<br>SignItから手話を投稿することもできます。",
 	"si-panel-videos-contribute-label": "手話で貢献する",
 	"si-panel-definitions-title": "定義:",

--- a/i18n/kk-cyrl.json
+++ b/i18n/kk-cyrl.json
@@ -9,7 +9,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Lingua Libre-де қолжетімді барлық видео тізімі алынып жатыр.",
 	"si-panel-videos-title": "Медиа:",
-	"si-panel-videos-gallery-attribution": "ауторы: <a href='$1' target='_blank'>$2</a> — $3/$4 видео",
+	"si-panel-videos-gallery-attribution": "ауторы: {{link:$1|$2}} — $3/$4 видео",
 	"si-panel-videos-empty": "Бұл сөз әлі жазылмаған,<br>бірақ SignIt краудсорсиң жобасы болғандықтан, сіз оған үлес қоса аласыз.",
 	"si-panel-videos-contribute-label": "Ым тілінмен үлес қосу",
 	"si-panel-definitions-title": "Мағыналары:",

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -9,7 +9,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Lingua Libre에서 사용 가능한 모든 동영상의 목록을 가져옵니다.",
 	"si-panel-videos-title": "미디어:",
-	"si-panel-videos-gallery-attribution": "만든이: <a href='$1' target='_blank'>$2</a> – 동영상 $3 / $4",
+	"si-panel-videos-gallery-attribution": "만든이: {{link:$1|$2}} – 동영상 $3 / $4",
 	"si-panel-videos-empty": "이 단어는 아직 녹화되지 않았습니다.<br>SignIt은 크라우드 소싱 프로젝트이므로 직접 기여할 수 있습니다.",
 	"si-panel-videos-contribute-label": "수화로 기여",
 	"si-panel-definitions-title": "정의:",

--- a/i18n/krc.json
+++ b/i18n/krc.json
@@ -7,7 +7,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Lingua Libre-де болгъан бютеу видеоланы тизмесин келтиреди.",
 	"si-panel-videos-title": "Медиа:",
-	"si-panel-videos-gallery-attribution": "<a href='$1' target='_blank'>$2</a> – Видео $3/$4",
+	"si-panel-videos-gallery-attribution": "{{link:$1|$2}} – Видео $3/$4",
 	"si-panel-videos-empty": "Бу сёз алкъын джаздырылмагъанды<br> алай а SignIt краудсорсинг проект болгъаны себебли, кесигизни юлюшюгюзню къошаргъа боллукъсуз.",
 	"si-panel-videos-contribute-label": "Къол силкиу тилде кесигизни юлюшюгюзню къошугъуз",
 	"si-panel-definitions-title": "Ачыкълау:",

--- a/i18n/lmo.json
+++ b/i18n/lmo.json
@@ -7,7 +7,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Adree a portà a voltra la lista de tucc i video disponibil in su Lengua Libre.",
 	"si-panel-videos-title": "Media:",
-	"si-panel-videos-gallery-attribution": "de <a href='$1' target='_blank'>$2</a> - Video $3 de $4",
+	"si-panel-videos-gallery-attribution": "de {{link:$1|$2}} - Video $3 de $4",
 	"si-panel-videos-empty": "Questa parolla chì l'è stada nan'mò registrada,<br>ma SignIt a l'è un proget in collaborazzion, te podet contribuì an' ti.",
 	"si-panel-videos-contribute-label": "Contribuiss con la lengua di segni",
 	"si-panel-definitions-title": "Definizzionː",

--- a/i18n/mk.json
+++ b/i18n/mk.json
@@ -8,7 +8,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Преземам список на сите видеоснимки достапни на Lingua Libre.",
 	"si-panel-videos-title": "Снимка:",
-	"si-panel-videos-gallery-attribution": "од <a href='$1' target='_blank'>$2</a> — Видео $3 од $4",
+	"si-panel-videos-gallery-attribution": "од {{link:$1|$2}} — Видео $3 од $4",
 	"si-panel-videos-empty": "Овој збор сè уште не е снимен,<br> но SignIt е проект со општо учество, и затоа и Вие можете да придонесувате.",
 	"si-panel-videos-contribute-label": "Учествувајте со знаковен јазик",
 	"si-panel-definitions-title": "Дефиниции:",

--- a/i18n/ms.json
+++ b/i18n/ms.json
@@ -8,7 +8,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Mengambil senarai semua video yang tersedia di Lingua Libre.",
 	"si-panel-videos-title": "Media:",
-	"si-panel-videos-gallery-attribution": "karya <a href='$1' target='_blank'>$2</a> – Video $3 dari $4",
+	"si-panel-videos-gallery-attribution": "karya {{link:$1|$2}} – Video $3 dari $4",
 	"si-panel-videos-empty": "Perkataan ini belum dirakam lagi,<br>tetapi SignIt adalah projek hasil usaha sama dari orang ramai, maka anda boleh memberi sumbangan.",
 	"si-panel-videos-contribute-label": "Menyumbang dengan Bahasa Isyarat",
 	"si-panel-definitions-title": "Definisi:",

--- a/i18n/nb.json
+++ b/i18n/nb.json
@@ -8,7 +8,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Henter lista over alle videoer som er tilgjengelig på Lingua Libre.",
 	"si-panel-videos-title": "Media:",
-	"si-panel-videos-gallery-attribution": "av <a href='$1' target='_blank'>$2</a> – video $3 av $4",
+	"si-panel-videos-gallery-attribution": "av {{link:$1|$2}} – video $3 av $4",
 	"si-panel-videos-empty": "Dette ordet har ikke blitt spilt inn ennå,<br>men SignIt er et dugnadsprosjekt, så du kan spille det inn.",
 	"si-panel-videos-contribute-label": "Bidra med tegnspråk",
 	"si-panel-definitions-title": "Definisjoner:",

--- a/i18n/pt-br.json
+++ b/i18n/pt-br.json
@@ -7,7 +7,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Buscando a lista de todos os vídeos disponíveis no Lingua Libre.",
 	"si-panel-videos-title": "Mídia:",
-	"si-panel-videos-gallery-attribution": "por <a href='$1' target='_blank'>$2</a> – Vídeo $3 de $4",
+	"si-panel-videos-gallery-attribution": "por {{link:$1|$2}} – Vídeo $3 de $4",
 	"si-panel-videos-empty": "Esta palavra ainda não foi gravada,<br /> mas SignIt é um projeto de crowdsourcingpara o qual você pode contribuir.",
 	"si-panel-videos-contribute-label": "Contribuir com a língua de sinais",
 	"si-panel-definitions-title": "Definições:",

--- a/i18n/pt.json
+++ b/i18n/pt.json
@@ -8,7 +8,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "A obter a lista de todos os vídeos disponíveis em Lingua Libre.",
 	"si-panel-videos-title": "Multimédia:",
-	"si-panel-videos-gallery-attribution": "de <a href='$1' target='_blank'>$2</a> – Vídeo $3 de $4",
+	"si-panel-videos-gallery-attribution": "de {{link:$1|$2}} – Vídeo $3 de $4",
 	"si-panel-videos-empty": "Esta palavra ainda não foi gravada,<br> mas como SignIt é um projeto de ''crowdsourcing'' pode participar nele.",
 	"si-panel-videos-contribute-label": "Contribuir com língua de sinais",
 	"si-panel-definitions-title": "Definições:",

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -8,7 +8,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Выдаёт список всех видео, доступных на Lingua Libre.",
 	"si-panel-videos-title": "Медиа:",
-	"si-panel-videos-gallery-attribution": "авторство: <a href='$1' target='_blank'>$2</a> – видео $3 в $4",
+	"si-panel-videos-gallery-attribution": "авторство: {{link:$1|$2}} – видео $3 в $4",
 	"si-panel-videos-empty": "Это слово еще не записано,<br> но SignIt — это краудсорсинговый проект, и вы можете внести свой вклад!",
 	"si-panel-videos-contribute-label": "Внесите свой вклад на жестовом языке",
 	"si-panel-definitions-title": "Определения:",

--- a/i18n/scn.json
+++ b/i18n/scn.json
@@ -7,7 +7,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Carricamentu di l'alencu di tutti li vìdii dispunìbbili supra Lingua Libre.",
 	"si-panel-videos-title": "Midia:",
-	"si-panel-videos-gallery-attribution": "di <a href='$1' target='_blank'>$2</a> – Vìdiu $3 di $4",
+	"si-panel-videos-gallery-attribution": "di {{link:$1|$2}} – Vìdiu $3 di $4",
 	"si-panel-videos-empty": "Sta palora nun è ancora riggistrata,<br>pirò SignIt è nu pruggettu participativu, a cui tu poi cuntribbuiri.",
 	"si-panel-videos-contribute-label": "Cuntribbuisci ntâ lingua dî signa",
 	"si-panel-definitions-title": "Difinizzioni:",

--- a/i18n/sl.json
+++ b/i18n/sl.json
@@ -7,7 +7,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Pridobivanje seznama vseh videoposnetkov, ki so na voljo v Lingua Libre.",
 	"si-panel-videos-title": "Predstavnosti:",
-	"si-panel-videos-gallery-attribution": "avtor <a href='$1' target='_blank'>$2</a> – video $3 od $4",
+	"si-panel-videos-gallery-attribution": "avtor {{link:$1|$2}} – video $3 od $4",
 	"si-panel-videos-empty": "Ta beseda še ni bila zapisana,<br> vendar je SignIt sodelovalni projekt in lahko prispevate k njemu.",
 	"si-panel-videos-contribute-label": "Prispevajte z znakovnim jezikom",
 	"si-panel-definitions-title": "Opredelitve:",

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -7,7 +7,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Hämtar listan över alla tillgängliga videor på Lingua Libre.",
 	"si-panel-videos-title": "Media:",
-	"si-panel-videos-gallery-attribution": "av <a href='$1' target='_blank'>$2</a> – Video $3 av $4",
+	"si-panel-videos-gallery-attribution": "av {{link:$1|$2}} – Video $3 av $4",
 	"si-panel-videos-empty": "Det här ordet har ännu inte spelats in,<br>men SignIt är ett samarbetsprojekt så du kan bidra med det.",
 	"si-panel-videos-contribute-label": "Bidra med teckenspråk",
 	"si-panel-definitions-title": "Definitioner:",

--- a/i18n/te.json
+++ b/i18n/te.json
@@ -8,7 +8,7 @@
 	"si-addon-title": "లింగ్వా లిబ్రే SignIt",
 	"si-addon-preload": "లింగ్వా లిబ్రే లో అందుబాటులో ఉన్న వీడియోలన్నిటి జాబితాను తెస్తున్నాం.",
 	"si-panel-videos-title": "మీడియా:",
-	"si-panel-videos-gallery-attribution": "కర్త: <a href='$1' target='_blank'>$2</a> – $4 వీడియోల్లో $3 వది",
+	"si-panel-videos-gallery-attribution": "కర్త: {{link:$1|$2}} – $4 వీడియోల్లో $3 వది",
 	"si-panel-videos-empty": "ఈ పదాన్ని ఇంకా రికార్డు చెయ్యలేదు,<br>కానీ SignIt క్రౌడ్ సోర్సు ప్రాజెక్టు, మీరు దానికి తోడ్పడవచ్చు.",
 	"si-panel-videos-contribute-label": "సంకేత భాషతో తోడ్పాటు నందించండి",
 	"si-panel-definitions-title": "నిర్వచనాలు:",

--- a/i18n/tl.json
+++ b/i18n/tl.json
@@ -7,7 +7,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Kinukuha ang listahan ng lahat ng mga magagamit na video sa Lingua Libre.",
 	"si-panel-videos-title": "Midya:",
-	"si-panel-videos-gallery-attribution": "ni <a href='$1' target='_blank'>$2</a> - Video $3 ng $4",
+	"si-panel-videos-gallery-attribution": "ni {{link:$1|$2}} - Video $3 ng $4",
 	"si-panel-videos-empty": "Hindi pa nare-record ang salitang ito,<b4>pero crowdsourced na proyekto ang SignIt, kaya naman pwede kang mag-ambag rito.",
 	"si-panel-videos-contribute-label": "Mag-ambag gamit ang Wikang Nakasenyas",
 	"si-panel-definitions-title": "Mga kahulugan:",

--- a/i18n/tr.json
+++ b/i18n/tr.json
@@ -7,7 +7,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Lingua Libre'de bulunan tüm videoların listesi getiriliyor.",
 	"si-panel-videos-title": "Medya:",
-	"si-panel-videos-gallery-attribution": "<a href='$1' target='_blank'>$2</a> – Video $3/$4",
+	"si-panel-videos-gallery-attribution": "{{link:$1|$2}} – Video $3/$4",
 	"si-panel-videos-empty": "Bu kelime henüz kaydedilmedi<br> ancak SignIt kitle kaynaklı bir projedir ve SignIt'e katkıda bulunabilirsiniz.",
 	"si-panel-videos-contribute-label": "İşaret Dili ile Katkıda Bulunun",
 	"si-panel-definitions-title": "Tanımlar:",

--- a/i18n/uk.json
+++ b/i18n/uk.json
@@ -7,7 +7,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "Отримання списку всіх відео, доступних на Lingua Libre.",
 	"si-panel-videos-title": "Медіа:",
-	"si-panel-videos-gallery-attribution": "від <a href='$1' target='_blank'>$2</a> – Відео $3 із $4",
+	"si-panel-videos-gallery-attribution": "від {{link:$1|$2}} – Відео $3 із $4",
 	"si-panel-videos-empty": "Це слово ще не записано,<br> але SignIt – це проект, створений натовпом, ви можете зробити свій внесок у нього.",
 	"si-panel-videos-contribute-label": "Зробіть внесок Мовою Жестів",
 	"si-panel-definitions-title": "Визначення:",

--- a/i18n/ur.json
+++ b/i18n/ur.json
@@ -7,7 +7,7 @@
 	"si-addon-title": "آزاد سائین بولی والا",
 	"si-addon-preload": "ساریاں ویڈیواں لبھیاں جا رہیاں۔",
 	"si-panel-videos-title": "میڈیا:",
-	"si-panel-videos-gallery-attribution": "<a href='$1' target='_blank'>$2</a> $4 توں ویڈیو $3 بݨائی اے",
+	"si-panel-videos-gallery-attribution": "{{link:$1|$2}} $4 توں ویڈیو $3 بݨائی اے",
 	"si-panel-videos-empty": "حالیہ ریکارڈ نہیں لبھیا،<br>پر تسیں ریکارڈ کر سکیو۔",
 	"si-panel-videos-contribute-label": "سائین بھاشا ورتو",
 	"si-panel-definitions-title": "تعریفاں:",

--- a/i18n/zh-hans.json
+++ b/i18n/zh-hans.json
@@ -10,7 +10,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "获取 Lingua Libre 上可提供的视频列表。",
 	"si-panel-videos-title": "视频：",
-	"si-panel-videos-gallery-attribution": "贡献者 <a href='$1' target='_blank'>$2</a> – 视频 $3 / $4",
+	"si-panel-videos-gallery-attribution": "贡献者 {{link:$1|$2}} – 视频 $3 / $4",
 	"si-panel-videos-empty": "该词汇尚无视频，<br>不过 SignIt 是一项众包项目，您可以参与其中并帮助完成。",
 	"si-panel-videos-contribute-label": "贡献你的手语",
 	"si-panel-definitions-title": "定义：",

--- a/i18n/zh-hant.json
+++ b/i18n/zh-hant.json
@@ -9,7 +9,7 @@
 	"si-addon-title": "Lingua Libre SignIt",
 	"si-addon-preload": "取得在 Lingua Libre 上的所有可用影片清單。",
 	"si-panel-videos-title": "媒體：",
-	"si-panel-videos-gallery-attribution": "貢獻者：<a href='$1' target='_blank'>$2</a> – 影片$3/$4",
+	"si-panel-videos-gallery-attribution": "貢獻者：{{link:$1|$2}} – 影片$3/$4",
 	"si-panel-videos-empty": "SignIt 是個群眾外包專案，<br>因此目前雖然尚無該字詞的影片，您可以參與其中來協助完成。",
 	"si-panel-videos-contribute-label": "以手語貢獻",
 	"si-panel-definitions-title": "定義：",


### PR DESCRIPTION
Since we are back to using the orginal library , I thought to reuse the previous `{{link}}` keywords rather than constructing anchors ourselves