### PR TITLE
feat : adding alarms API

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -17,7 +17,7 @@
     "storage",
     "webRequest",
     "webRequestBlocking",
-    "offscreen"
+    "alarms"
   ],
   "content_scripts": [
     {

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -382,15 +382,10 @@ var browser = (browserType === 'firefox') ? browser : (browserType === 'chrome')
 		ui = new UI();
 		ui.switchPanel( 'loaded' );
 	}
-
-	let state = _backgroundPage.state;
-	function waitWhileLoading() {
-		if (state === 'ready' ) {
-			ui = new UI();
-		} else {
-			setTimeout( waitWhileLoading, 100 );
-		}
-	}
-	waitWhileLoading()
-
+	chrome.runtime.onMessage.addListener((message, sender) => {
+    console.log(sender);
+    if (message.state === "ready") {
+      ui = new UI();
+    }
+  });
 })();

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -382,10 +382,21 @@ var browser = (browserType === 'firefox') ? browser : (browserType === 'chrome')
 		ui = new UI();
 		ui.switchPanel( 'loaded' );
 	}
-	chrome.runtime.onMessage.addListener((message, sender) => {
-		console.log(sender);
-		if (message.state === "ready") {
-			ui = new UI();
-		}
+	if (browserType === "chrome") {
+    chrome.runtime.onMessage.addListener((message, sender) => {
+      if (message.state === "ready") {
+        ui = new UI();
+      }
     });
+	} else {
+		let state = _backgroundPage.state;
+		function waitWhileLoading() {
+		if (state === "ready") {
+			ui = new UI();
+		} else {
+			setTimeout(waitWhileLoading, 100);
+		}
+		}
+		waitWhileLoading();
+	}
 })();

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -382,10 +382,21 @@ var browser = (browserType === 'firefox') ? browser : (browserType === 'chrome')
 		ui = new UI();
 		ui.switchPanel( 'loaded' );
 	}
-	chrome.runtime.onMessage.addListener((message, sender) => {
-		console.log(sender);
-		if (message.state === "ready") {
-			ui = new UI();
-		}
+	if (browserType === "chrome") {
+    chrome.runtime.onMessage.addListener((message, sender) => {
+      if (message.state === "ready") {
+        ui = new UI();
+      }
     });
+  } else {
+    let state = _backgroundPage.state;
+    function waitWhileLoading() {
+      if (state === "ready") {
+        ui = new UI();
+      } else {
+        setTimeout(waitWhileLoading, 100);
+      }
+    }
+    waitWhileLoading();
+  }
 })();

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -383,9 +383,9 @@ var browser = (browserType === 'firefox') ? browser : (browserType === 'chrome')
 		ui.switchPanel( 'loaded' );
 	}
 	chrome.runtime.onMessage.addListener((message, sender) => {
-    console.log(sender);
-    if (message.state === "ready") {
-      ui = new UI();
-    }
-  });
+		console.log(sender);
+		if (message.state === "ready") {
+			ui = new UI();
+		}
+    });
 })();

--- a/sw.js
+++ b/sw.js
@@ -769,11 +769,28 @@ async function setState(value) {
 // Run it
 main();
 
+const WAIT_ALARM = 'waitWhileLoading';
+async function createAlarm() {
+  await chrome.alarms.create(WAIT_ALARM, {
+    periodInMinutes: 1 / 60 // by specifying it as fraction we can run the ⏰ in every 1 second
+  },()=>console.log('⏰ running inside createAlarm()',new Date().getSeconds()));
+}
+
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 	if (message.command === "getBackground") {
-    // persisted the state inside chrome.storage.local but will get to that later
-    console.log(state);
     const extensionData = {state,params,uiLanguages,records,signLanguages};
     sendResponse(extensionData);
+    createAlarm();
 	}
 });
+
+chrome.alarms.onAlarm.addListener((alarm)=>{
+  if (alarm.name === WAIT_ALARM) {
+    if (state === 'ready') {
+      chrome.runtime.sendMessage({state:'ready'});
+        chrome.alarms.clear(WAIT_ALARM,()=>{
+        console.log('⏰ stopped at ',new Date().getSeconds());
+      });
+    }
+  }
+})

--- a/sw.js
+++ b/sw.js
@@ -773,7 +773,7 @@ const WAIT_ALARM = 'waitWhileLoading';
 async function createAlarm() {
   await chrome.alarms.create(WAIT_ALARM, {
     periodInMinutes: 1 / 60 // by specifying it as fraction we can run the ⏰ in every 1 second
-  },()=>console.log('⏰ running inside createAlarm()',new Date().getSeconds()));
+  });
 }
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
@@ -788,9 +788,7 @@ chrome.alarms.onAlarm.addListener((alarm)=>{
   if (alarm.name === WAIT_ALARM) {
     if (state === 'ready') {
       chrome.runtime.sendMessage({state:'ready'});
-        chrome.alarms.clear(WAIT_ALARM,()=>{
-        console.log('⏰ stopped at ',new Date().getSeconds());
-      });
+        chrome.alarms.clear(WAIT_ALARM);
     }
   }
 })


### PR DESCRIPTION
## Changes

- [chore:added alarms permission](https://github.com/lingua-libre/SignIt/commit/6fb7a0b3c6e03c8cb5db92289823b9df1b4510ef) - added alarms permission in `manifest.json`
- [feat : added alarm functionality](https://github.com/lingua-libre/SignIt/pull/97/commits/5dc3e3e6226cd65d7d3ecfdf389fd332d7694cb3) - added alarm functionality inside service_worker. Despite minimum period being 0.5 minutes for an alarm , if we set it it as fraction , we can trigger it in 10 seconds as shown in commit.

> Whats actually happening is , whenver user selects the extension icon, along with `getBackground` command `createAlarm`
> function is triggered , which creates the alarm. Now our alarm isn't supposed to do anything , we don't have to do any periodic tasks like pinging the user to drink water after 1 min ,etc. We just have to wait for the state of the extension ot be ready and once it is ready , it will send a message to the popup which upon receving the message will initialize the UI, as mentioned in [refactor: Initialize UI with respect to alarms API](https://github.com/lingua-libre/SignIt/pull/97/commits/9a4fd41760841ac73ae8088314a6be79ff37aeec).
> 

- [revert : keeping the old approach for Firefox](https://github.com/lingua-libre/SignIt/pull/97/commits/f6b6e7169a3072be47002bf811864718f588cb2f) - While alarms are the best approach when working with service_workers , the old approach of using `setTimeout` still works in persistent backgroundPage which we use for **Firefox**. So keeping it now for temporary testing purposes.