### PR TITLE
Refactor/callbacks to promises

### DIFF
--- a/popup/popup.js
+++ b/popup/popup.js
@@ -10,10 +10,9 @@ var browser = (browserType === 'firefox') ? browser : (browserType === 'chrome')
 	if (browserType === "chrome") {
     // Use Chrome Extensions API,
     async function getBackgroundPage() {
-      return new Promise((resolve) => {
-        chrome.runtime.sendMessage({ command: "getBackground" }, (response) => {
-          resolve(response);
-        });
+      return new Promise(async(resolve) => {
+		let response  = await chrome.runtime.sendMessage({ command: "getBackground" });
+		resolve(response);
       });
     }
     _backgroundPage = await getBackgroundPage();


### PR DESCRIPTION
## Changes

As mentioned in [docs](https://developer.chrome.com/docs/extensions/develop/migrate/api-calls#replace-callbacks) , we had to replace extension methods which used callabacks with promises. This was the only code I could find which used a callback in extension API methods. Inside other methods , we have used promises to await their responses and then worked further ahead. Although I still encourage @hugolpz and @Ishan-Saini  to go through the codebase and find if there is some method I missed.

With this we can close #98 .