### PR TITLE
Feat/replace blocking web request listeners

### DIFF
--- a/SignItVideosGallery.js
+++ b/SignItVideosGallery.js
@@ -41,7 +41,7 @@ SignItVideosGallery.prototype.refresh = async function ( files ) {
 		console.log(await banana.i18n("si-panel-videos-gallery-attribution",url, speaker, i+1, total));
 		this.$videos.push( $( `
 			<div style="display: none;">
-				<iframe controls="" muted="" preload="auto" src="${ files[ i ].filename }" width="250" class=""></iframe>
+				<iframe controls="" muted="" preload="auto" src="${ files[ i ].filename }" class="" allow="autoplay *"></iframe>
 				${await banana.i18n("si-panel-videos-gallery-attribution",url, speaker, i+1, total)}
 			</div>
 		` ) );

--- a/SignItVideosGallery.js
+++ b/SignItVideosGallery.js
@@ -41,7 +41,7 @@ SignItVideosGallery.prototype.refresh = async function ( files ) {
 		console.log(await banana.i18n("si-panel-videos-gallery-attribution",url, speaker, i+1, total));
 		this.$videos.push( $( `
 			<div style="display: none;">
-				<video controls="" muted="" preload="auto" src="${ files[ i ].filename }" width="250" class=""></video>
+				<iframe controls="" muted="" preload="auto" src="${ files[ i ].filename }" width="250" class=""></iframe>
 				${await banana.i18n("si-panel-videos-gallery-attribution",url, speaker, i+1, total)}
 			</div>
 		` ) );

--- a/SignItVideosGallery.js
+++ b/SignItVideosGallery.js
@@ -57,7 +57,7 @@ SignItVideosGallery.prototype.switchVideo = function ( newIndex ) {
 	this.$videos[ this.currentIndex ].hide();
 	this.currentIndex = newIndex;
 	this.$videos[ this.currentIndex ].show();
-	$currentVideo = this.$videos[ this.currentIndex ].children( 'video' )[ 0 ];
+	$currentVideo = this.$videos[ this.currentIndex ].children( 'iframe' )[ 0 ];
 
 	$( async function () {
 		param = await browser.storage.local.get( 'twospeed' );
@@ -83,9 +83,6 @@ SignItVideosGallery.prototype.switchVideo = function ( newIndex ) {
 			})
 		}
 	})
-
-	// After switching, play
-	$currentVideo.play();
 
 	// Arrows disables when on edges
 	this.currentIndex === 0 ?

--- a/background-script.js
+++ b/background-script.js
@@ -333,22 +333,25 @@ async function checkActiveTabInjections( tab ) {
 }
 
 // Edit the header of all pages on-the-fly to bypass Content-Security-Policy
-browser.webRequest.onHeadersReceived.addListener(info => {
-    const headers = info.responseHeaders; // original headers
-    for (let i=headers.length-1; i>=0; --i) {
-        let header = headers[i].name.toLowerCase();
-        if (header === "content-security-policy") { // csp header is found
-            // modifying media-src; this implies that the directive is already present
-            headers[i].value = headers[i].value.replace("media-src", "media-src https://commons.wikimedia.org https://upload.wikimedia.org");
-        }
-    }
-    // return modified headers
-    return {responseHeaders: headers};
-}, {
-    urls: [ "<all_urls>" ], // match all pages
-    types: [ "main_frame" ] // to focus only the main document of a tab
-}, ["blocking", "responseHeaders"]);
+// browser.webRequest.onHeadersReceived.addListener(info => {
+// 	const headers = info.responseHeaders; // original headers
+// 	console.log(headers);
+//     for (let i=headers.length-1; i>=0; --i) {
+//         let header = headers[i].name.toLowerCase();
+//         if (header === "content-security-policy") { // csp header is found
+//             // modifying media-src; this implies that the directive is already present
+//             headers[i].value = headers[i].value.replace("media-src", "media-src https://commons.wikimedia.org https://upload.wikimedia.org");
+//         }
+//     }
+//     // return modified headers
+//     return {responseHeaders: headers};
+// }, {
+//     urls: [ "<all_urls>" ], // match all pages
+//     types: [ "main_frame" ] // to focus only the main document of a tab
+// }, ["blocking", "responseHeaders"]);
 
+browser.declarativeNetRequest.getAvailableStaticRuleCount(numOfRulesThatCanStillBeAdded=>console.log(numOfRulesThatCanStillBeAdded));
+browser.declarativeNetRequest.getEnabledRulesets(id=>console.log(id)); // this shows the id we set inside our dnr.rule_resources in manifest.json
 
 /* *************************************************************** */
 /* Browser interactions ****************************************** */

--- a/background-script.js
+++ b/background-script.js
@@ -332,27 +332,6 @@ async function checkActiveTabInjections( tab ) {
 	}
 }
 
-// Edit the header of all pages on-the-fly to bypass Content-Security-Policy
-// browser.webRequest.onHeadersReceived.addListener(info => {
-// 	const headers = info.responseHeaders; // original headers
-// 	console.log(headers);
-//     for (let i=headers.length-1; i>=0; --i) {
-//         let header = headers[i].name.toLowerCase();
-//         if (header === "content-security-policy") { // csp header is found
-//             // modifying media-src; this implies that the directive is already present
-//             headers[i].value = headers[i].value.replace("media-src", "media-src https://commons.wikimedia.org https://upload.wikimedia.org");
-//         }
-//     }
-//     // return modified headers
-//     return {responseHeaders: headers};
-// }, {
-//     urls: [ "<all_urls>" ], // match all pages
-//     types: [ "main_frame" ] // to focus only the main document of a tab
-// }, ["blocking", "responseHeaders"]);
-
-browser.declarativeNetRequest.getAvailableStaticRuleCount(numOfRulesThatCanStillBeAdded=>console.log(numOfRulesThatCanStillBeAdded));
-browser.declarativeNetRequest.getEnabledRulesets(id=>console.log(id)); // this shows the id we set inside our dnr.rule_resources in manifest.json
-
 /* *************************************************************** */
 /* Browser interactions ****************************************** */
 var callModal = async function(msg){

--- a/content_scripts/signit.css
+++ b/content_scripts/signit.css
@@ -69,7 +69,7 @@
   align-items: center;
 }
 
-.signit-video video {
+.signit-video iframe {
   box-shadow: 0 0 0.5rem #999;
   width: 100%;
 }

--- a/content_scripts/wpintegration.css
+++ b/content_scripts/wpintegration.css
@@ -6,7 +6,7 @@
 	max-width: 300px;
 }
 
-.signit-inline-container video {
+.signit-inline-container iframe {
 	box-shadow: 0 0 .5rem #999;
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -10,13 +10,22 @@
 	  "48": "icons/Lingualibre_SignIt-logo-no-text-square-48.png",
 	  "64": "icons/Lingualibre_SignIt-logo-no-text-square-64.png"
 	},
+	"declarative_net_request": {
+		"rule_resources": [
+			{
+				"id": "1",
+				"enabled": true,
+				"path": "rules.json"
+			}
+		]
+	},
 	"permissions": [
     "scripting",
     "activeTab",
     "contextMenus",
     "storage",
     "webRequest",
-    "webRequestBlocking",
+    "declarativeNetRequest",
     "alarms"
   ],
   "host_permissions":["https://*/*"],

--- a/manifest.json
+++ b/manifest.json
@@ -19,6 +19,7 @@
     "webRequestBlocking",
     "alarms"
   ],
+  "host_permissions":["https://*/*"],
   "content_scripts": [
     {
       "matches": [

--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,7 @@
 	"declarative_net_request": {
 		"rule_resources": [
 			{
-				"id": "1",
+				"id": "ruleset",
 				"enabled": true,
 				"path": "rules.json"
 			}

--- a/manifest.json
+++ b/manifest.json
@@ -10,22 +10,12 @@
 	  "48": "icons/Lingualibre_SignIt-logo-no-text-square-48.png",
 	  "64": "icons/Lingualibre_SignIt-logo-no-text-square-64.png"
 	},
-	"declarative_net_request": {
-		"rule_resources": [
-			{
-				"id": "ruleset",
-				"enabled": true,
-				"path": "rules.json"
-			}
-		]
-	},
 	"permissions": [
     "scripting",
     "activeTab",
     "contextMenus",
     "storage",
     "webRequest",
-    "declarativeNetRequest",
     "alarms"
   ],
   "host_permissions":["https://*/*"],

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -185,7 +185,7 @@ html, body {
 	align-items: center;
 }
 
-.signit-video video {
+.signit-video iframe {
 	box-shadow: 0 0 .5rem #999;
 	width: 345px;
 }

--- a/rules.json
+++ b/rules.json
@@ -1,11 +1,21 @@
 [
     {
-      "id" : 1,
-      "priority": 1,
-      "action" : { "type" : "modifyHeaders" },
-      "condition" : {
-        "urlFilter" : "|https*",
-        "resourceTypes" : ["main_frame"]
-      }
+        "id": 1,
+        "priority": 1,
+        "action": {
+            "type": "modifyHeaders",
+            "responseHeaders": [
+                {
+                    "header": "content-security-policy",
+                    "operation": "set"
+                }
+            ]
+        },
+        "condition": {
+            "urlFilter": "|https*",
+            "resourceTypes": [
+                "main_frame"
+            ]
+        }
     }
-  ]
+]

--- a/rules.json
+++ b/rules.json
@@ -1,0 +1,11 @@
+[
+    {
+      "id" : 1,
+      "priority": 1,
+      "action" : { "type" : "modifyHeaders" },
+      "condition" : {
+        "urlFilter" : "|https*",
+        "resourceTypes" : ["main_frame"]
+      }
+    }
+  ]

--- a/rules.json
+++ b/rules.json
@@ -6,8 +6,9 @@
             "type": "modifyHeaders",
             "responseHeaders": [
                 {
-                    "header": "content-security-policy",
-                    "operation": "set"
+                    "header": "Content-Security-Policy",
+                    "operation": "set",
+                    "value": "media-src https://commons.wikimedia.org https://upload.wikimedia.org"
                 }
             ]
         },

--- a/sw.js
+++ b/sw.js
@@ -638,6 +638,9 @@ async function setState(value) {
     }
   }
 
+browser.declarativeNetRequest.getAvailableStaticRuleCount(numOfRulesThatCanStillBeAdded=>console.log(numOfRulesThatCanStillBeAdded));
+browser.declarativeNetRequest.getEnabledRulesets(id=>console.log(id)); // this shows the id we set inside our dnr.rule_resources in manifest.json
+
   /* Browser interactions ****************************************** */
   var callModal = async function (msg) {
     // Tab

--- a/sw.js
+++ b/sw.js
@@ -638,9 +638,6 @@ async function setState(value) {
     }
   }
 
-browser.declarativeNetRequest.getAvailableStaticRuleCount(numOfRulesThatCanStillBeAdded=>console.log(numOfRulesThatCanStillBeAdded));
-browser.declarativeNetRequest.getEnabledRulesets(id=>console.log(id)); // this shows the id we set inside our dnr.rule_resources in manifest.json
-
   /* Browser interactions ****************************************** */
   var callModal = async function (msg) {
     // Tab


### PR DESCRIPTION
## Description

As the title suggests we had to replace blocking web request listeners with `delarativeNetRequest` API. The `declarativeNetRequest` API is used to block or modify network requests by specifying declarative rules. This lets extensions modify network requests without intercepting them and viewing their content, thus providing more privacy. Also it turns out to be more performant than what was being used earlier. If we talk about browser compatibility , then majority of its methods are accessible and compatible across all browsers. Some methods like `getMatchedRules` is not compatible in FF and similar methods exist for other browsers as well. Not that they were used here, but still , it is something to be kept in mind.

Also , despite the issue #100 being raised in context of `background-script.js` , the changes apply to both chromium browsers and FF, since changes are being made to `manifest.json`, they apply to both.

## Question that still remains

Why were we modifying headers to begin with ? Like I am aware that we often need to modify headers but what were we achieving here by doing that ?

## Changes made : 

Anyways , despite all of this, I went ahead to change the current piece of code. I believe all the commit messages are self explanatory. I'd like to emphasize on [test : confirming whether the headers have been modified by DNR](https://github.com/lingua-libre/SignIt/commit/93d205359304ee340b9aa5dde53a825b3aae97e0). As per DNR API , minimum number of static rules that we can add is **30,000** as per [mdn](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/GUARANTEED_MINIMUM_STATIC_RULES). So in order to confirm that our given rule has been added , we should get a number less than 30k i.e., **29,999**. There are other ways to confirm it as well , like checking the CSP response header under network tab of DevTools.

## Issue

While everything remains same on the front-end , things indeed change with its introduction. Videos stop working on youtube site. They stop at thumbnail. While nobody is going to use our extension on Youtube definitely , **if installed and is active can lead to client side confusion**. It has **something to do with the way I am modifying the header**, I haven't fully understood this yet ,hope @hugolpz and @Ishan-Saini can look into it , but with this present #100 can't be closed yet. I'll be refactoring this later , adding either more rules or some kind of `urlFilter` but until then this is what I could come up with.

## Challenges faced 

- `declarativeNetRequest` API is not fully functional. We can't append headers or use regex to match cases. Despite mentioning in the docs it seems like it is not fully reliable. The [conversation](https://github.com/w3c/webextensions/issues/626#issuecomment-2203050200) here sums it pretty well. 

The other alternatives were to either use `blob` URL and `iframe` tag. 

- `blob` URL works in such a way that it creates a blob object out of the given data (video in our case), which can then be used to make a file or URL.The URL created through blob is a part of the host site  , so there is no chance that it can violate CSP header. While it worked on youtube , we got the same CSP Violation error on Github , so this was the end of road for blob url. With this #102 can be closed.
- **Solution :** `iframe` tag embeds the video inside the content script ,so there is no chance of violation of CSP `media-src` directive. It indeed works on all the sites with strict CSP headers like youtube / github etc. Although it comes with it's own set of problems.
  - As mentioned [here](https://developer.mozilla.org/en-US/docs/Web/API/HTMLIFrameElement/contentDocument) , the embedded document should belong to the parent document , otherwise it returns `null`. And since our videos belong to origin with `wikimedia` subdomains, we can never have the same origin, due to which accessing the inner video element is not possible. 
  - Due to this inability , feature like `twospeed` won't work properly , since they worked around `video` element and not `iframe`.
  
## Conclusion 

> Hello @kabir-afk , thanks for the in depth analysis. iframe seems a good idea. Could iframe interfer or prevent the `twospeed` feature ? But if it does then lets just put that feature aside for sanity sake. It will provide something to do for the GSoC25 : )

If we can do so , then `iframe` remains the best and final choice, With this #100 can be closed now.