### PR TITLE
Refactor/twospeed

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ See also [Mozilla's web-ext](https://github.com/mozilla/web-ext)
 ├── sw.js — main script for Chromium browsers.
 ├── SignItCoreContent.js — creates duo panels "Video | Definition"
 ├── SignItVideosGallery.js — given urls, creates gallery of videos.
+├── SignItVideosIframe.html — contains intermediate iframe for videos and twsospeed feature.
 ├── content_scripts/
 |   ├── signit.js — creates above text SignIt popup
 |   └── wpintegration.js — on wikimedia sites, if page's title has a sign language video available, then display smartly.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Chrome web store had started deprecating the web extensions with manifest versio
  While there were other options like making your own i18n function , based on the arguments received from `sw.js` , but that was a repetitive task when using i18n inside multiple files.
  
  Other option was to use `browser.i18n` native API. This was an ok option but didn't allow users to change to their desired language , only changed them when browser's language was different. For someone who didn't want the extension to run in his native language or wanted to run it in different language had no control.
-* iframe instead of video tag : While this fix was made so that extension could work on sites with stricter CSPs like github or X, this broke the `twospeed` feature. The `twospeed` feature , when enabled allowed the users to see sign language video first in normal speed then in slow mo. It's code worked with event listeners of video tag , but since we replaced it with iframe , this feature no longer works. While you might think that accessing content document inside  iframe is no biggie , it doesn't work as the video embedded and the parent inside which the iframe is embedded in belong to different origins. Again this is something that can and should be improvised by future devs reading this.
+* iframe instead of video tag : This fix was made so that extension could work on sites with stricter CSPs like github or X. `declarativeNetRequest` API was certainly an alternative but it is not yet fully functional. We can't append headers , not even a single one despite being mentioned in docs.
 
 ## Contribute
 ### Contributors

--- a/SignItVideosGallery.js
+++ b/SignItVideosGallery.js
@@ -39,9 +39,11 @@ SignItVideosGallery.prototype.refresh = async function ( files ) {
 		speaker = files[ i ].speaker,
 		total = files.length;
 		console.log(await banana.i18n("si-panel-videos-gallery-attribution",url, speaker, i+1, total));
+		param = await browser.storage.local.get( 'twospeed' );
+
 		this.$videos.push( $( `
 			<div style="display: none;">
-				<iframe controls="" muted="" preload="auto" src="${ files[ i ].filename }" class="" allow="autoplay *"></iframe>
+				<iframe controls="" muted="" preload="auto" src="https://lingua-libre.github.io/SignIt/SignItVideosIframe.html?twospeed=${param.twospeed}&video=${ files[ i ].filename }" class=""></iframe>
 				${await banana.i18n("si-panel-videos-gallery-attribution",url, speaker, i+1, total)}
 			</div>
 		` ) );

--- a/SignItVideosGallery.js
+++ b/SignItVideosGallery.js
@@ -53,44 +53,16 @@ SignItVideosGallery.prototype.refresh = async function ( files ) {
 	this.switchVideo( 0 );
 };
 
-SignItVideosGallery.prototype.switchVideo = function ( newIndex ) {
-	var speedNormal = 1, speedSlow = 0.5;
+SignItVideosGallery.prototype.switchVideo = function (newIndex) {
+  this.$videos[this.currentIndex].hide();
+  this.currentIndex = newIndex;
+  this.$videos[this.currentIndex].show();
 
-	this.$videos[ this.currentIndex ].hide();
-	this.currentIndex = newIndex;
-	this.$videos[ this.currentIndex ].show();
-	$currentVideo = this.$videos[ this.currentIndex ].children( 'iframe' )[ 0 ];
-
-	$( async function () {
-		param = await browser.storage.local.get( 'twospeed' );
-		if ( param.twospeed === false ) {
-			console.warn( 'twospeed disabled' );
-			return;
-		}
-		// addClass(), removeClass(), and toggleClass()
-		if ( param.twospeed === true ) {
-			$currentVideo.addEventListener('ended', function(event) {
-				// Normal speed just played
-				if (!this.classList.contains('slow')) {
-					this.classList.add('slow');
-					this.playbackRate = speedSlow || 0.75;
-					this.play();
-				}
-				// Slow speed just played
-				else {
-					this.classList.remove('slow');
-					this.playbackRate = speedNormal || 1;
-					this.pause();
-				}
-			})
-		}
-	})
-
-	// Arrows disables when on edges
-	this.currentIndex === 0 ?
-		this.previousVideoButton.setDisabled( true )
-		:this.previousVideoButton.setDisabled( false );
-	this.currentIndex >= this.$videos.length - 1 ?
-		this.nextVideoButton.setDisabled( true )
-		:this.nextVideoButton.setDisabled( false );
+  // Arrows disables when on edges
+  this.currentIndex === 0
+    ? this.previousVideoButton.setDisabled(true)
+    : this.previousVideoButton.setDisabled(false);
+  this.currentIndex >= this.$videos.length - 1
+    ? this.nextVideoButton.setDisabled(true)
+    : this.nextVideoButton.setDisabled(false);
 };

--- a/manifest.json
+++ b/manifest.json
@@ -88,7 +88,7 @@
     }
   },
   "content_security_policy": {
-    "extension_pages": "default-src 'self' data: https://lingualibre.org https://*.wikimedia.org https://*.wikipedia.org https://*.wiktionary.org; script-src 'self';  style-src 'self' 'unsafe-inline'; img-src 'self' data",
+    "extension_pages": "default-src 'self' data: https://lingualibre.org https://*.wikimedia.org https://*.wikipedia.org https://*.wiktionary.org https://*.github.io/; script-src 'self';  style-src 'self' 'unsafe-inline'; img-src 'self' data",
     "sandbox": "sandbox allow-scripts allow-forms allow-popups allow-modals; script-src 'self' 'unsafe-inline' 'unsafe-eval'; child-src 'self';"
   },
   "action": {


### PR DESCRIPTION
## Description

As mentioned in previous PR , `video` tag was replaced by `iframe`. While this allowed our extension to work on sites with strict CSP headers like Github or X, it also broke `twospeed` feature. The `twospeed` feature enabled users to view the video first in normal speed and then in slow mo.

To counter this @hugolpz came up with the approach of using video hosted on github pages ,set as `iframe`'s src. While iframe didn't violate CSP headers' media-src directive, using a page that is hosted by us allowed us to manipulate the DOM and have control over the embedded video. Hence the `twospeed` feature is back again.

The way this works goes something like this :
 - [refactor : changed iframe's src attribute](https://github.com/lingua-libre/SignIt/commit/e5e9a8256a9c6547c96d8d21628386f74a1aeba7) - When embedding video inside iframe we pass the link of the github pages hosted site along with our **desired video** and **`twospeed` value as query parameters**.
 - #108  - Inside our page , we manipulate the DOM such that we extract the video URL  and `twospeed` value from URL of our page, embed the video inside another iframe , access the element by Id and implement the `twospeed` feature when the video is ended given the value is true.
 - [update : CSP directive to allow github.io sub-domains](https://github.com/lingua-libre/SignIt/commit/3cfae095383aa8365220d51b371533a34fb98e2f) - This needed to be done otherwise the video couldn't play in popup.
 - [code cleanup](https://github.com/lingua-libre/SignIt/commit/7747c83a7ac83a7c3da744d0402444d7df09b15a) - Since code related to the above feature was already in a different file , I thought of cleaning the code base to avoid any confusion.
 
 With this our extension would work on all the sites , even the ones with strict CSP values and we won't be lacking on any other features as well and #107 can be closed!