### PR TITLE
feat : overlay buttons

### DIFF
--- a/SignItVideosGallery.js
+++ b/SignItVideosGallery.js
@@ -10,7 +10,7 @@ var SignItVideosGallery = function (container) {
   this.nextVideoButton = new OO.ui.ButtonWidget({
     icon: "nextBtn",
     framed: false,
-    classes: ["signit-gallery-videos-button", "signit-gallery-videos-next"],
+    classes: ["signit-gallery-videos-buttons", "signit-gallery-videos-next"],
   });
   this.$videoContainer = $('<div class="signit-panel-videos-gallery">');
 
@@ -38,34 +38,31 @@ const styles = `
   .signit-panel-videos {
     text-align: center;
   }
-  .signit-gallery-videos {
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  .signit-panel-videos-gallery{
+    width: 100%;
+    position:relative;
   }
   .signit-panel-videos-gallery iframe,
   .signit-gallery-videos iframe {
     box-shadow: 0 0 0.5rem #999;
     width: 100%;
-    border: none;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    padding: 10px;
-    margin-right: -50px;
     min-height: 220px;
   }
   .signit-gallery-videos-buttons {
+    position : absolute;
+    top:50%;
+    transform : translateX(-50%);
     background-color: white; /* Customize the background color */       
     border: none;              /* Remove the border */
     border-radius: 5px;        /* Rounded corners */
     cursor: pointer;           /* Pointer cursor on hover */
   }
   .signit-gallery-videos-prev {
-    float: left;               /* Align to the left */
-  }
-  .signit-gallery-videos-next {
-    float: right;              /* Align to the right */
+      z-index:1;
+      left : 10%;
+    }
+    .signit-gallery-videos-next {
+      left : 40%;
   }
   .signit-gallery-videos-gallery {
     position: relative;
@@ -114,7 +111,7 @@ SignItVideosGallery.prototype.refresh = async function (files) {
       $(`
 			<div style="display: none;">
 				<iframe controls="" muted="" preload="auto"
-        src="https://lingua-libre.github.io/SignIt/SignItVideosIframe.html?width=250&twospeed=${param.twospeed}&video=${files[i].filename}" class=""></iframe>
+        src="https://lingua-libre.github.io/SignIt/SignItVideosIframe.html?width=370&twospeed=${param.twospeed}&video=${files[i].filename}" class=""></iframe>
 				${await banana.i18n(
           "si-panel-videos-gallery-attribution",
           url,

--- a/SignItVideosGallery.js
+++ b/SignItVideosGallery.js
@@ -33,40 +33,6 @@ var SignItVideosGallery = function (container) {
   );
 };
 
-const styles = `
-<style type="text/css">
-  .signit-panel-videos {
-    position:relative;
-    text-align: center;
-  }
-  .signit-panel-videos-gallery{
-    width: 100%;
-  }
-  .signit-panel-videos-gallery iframe,
-  .signit-gallery-videos iframe {
-    box-shadow: 0 0 0.5rem #999;
-    width: 100%;
-    min-height: 220px;
-    }
-    .signit-gallery-videos-buttons {
-    position : absolute;
-    top:40%;
-    transform : translate(-50%);
-    background-color: white; /* Customize the background color */       
-    border: none;              /* Remove the border */
-    border-radius: 5px;        /* Rounded corners */
-    cursor: pointer;           /* Pointer cursor on hover */
-  }
-  .signit-gallery-videos-prev {
-      z-index:1;
-      left : 10%;
-    }
-    .signit-gallery-videos-next {
-      left : 90%;
-  }
-</style>
-`;
-document.head.insertAdjacentHTML("beforeend", styles);
 SignItVideosGallery.prototype.refresh = async function (files) {
   var banana = {
     i18n: async (msg, ...arg) => {

--- a/SignItVideosGallery.js
+++ b/SignItVideosGallery.js
@@ -114,7 +114,7 @@ SignItVideosGallery.prototype.refresh = async function (files) {
       $(`
 			<div style="display: none;">
 				<iframe controls="" muted="" preload="auto"
-        src="https://lingua-libre.github.io/SignIt/SignItVideosIframe.html?width=2700&twospeed=${param.twospeed}&video=${files[i].filename}" class=""></iframe>
+        src="https://lingua-libre.github.io/SignIt/SignItVideosIframe.html?width=250&twospeed=${param.twospeed}&video=${files[i].filename}" class=""></iframe>
 				${await banana.i18n(
           "si-panel-videos-gallery-attribution",
           url,

--- a/SignItVideosGallery.js
+++ b/SignItVideosGallery.js
@@ -36,22 +36,22 @@ var SignItVideosGallery = function (container) {
 const styles = `
 <style type="text/css">
   .signit-panel-videos {
+    position:relative;
     text-align: center;
   }
   .signit-panel-videos-gallery{
     width: 100%;
-    position:relative;
   }
   .signit-panel-videos-gallery iframe,
   .signit-gallery-videos iframe {
     box-shadow: 0 0 0.5rem #999;
     width: 100%;
     min-height: 220px;
-  }
-  .signit-gallery-videos-buttons {
+    }
+    .signit-gallery-videos-buttons {
     position : absolute;
-    top:50%;
-    transform : translateX(-50%);
+    top:40%;
+    transform : translate(-50%);
     background-color: white; /* Customize the background color */       
     border: none;              /* Remove the border */
     border-radius: 5px;        /* Rounded corners */
@@ -62,12 +62,7 @@ const styles = `
       left : 10%;
     }
     .signit-gallery-videos-next {
-      left : 40%;
-  }
-  .signit-gallery-videos-gallery {
-    position: relative;
-    overflow: hidden;
-    height: auto;
+      left : 90%;
   }
 </style>
 `;

--- a/content_scripts/wpintegration.css
+++ b/content_scripts/wpintegration.css
@@ -1,3 +1,32 @@
+.signit-panel-videos {
+    position:relative;
+    text-align: center;
+}
+.signit-panel-videos-gallery{
+    width: 100%;
+}
+.signit-panel-videos-gallery iframe,
+.signit-gallery-videos iframe {
+    box-shadow: 0 0 0.5rem #999;
+    width: 100%;
+    min-height: 220px;
+}
+.signit-gallery-videos-buttons {
+	position : absolute;
+	top:40%;
+	transform : translate(-50%);
+	background-color: white; /* Customize the background color */       
+	border: none;              /* Remove the border */
+	border-radius: 5px;        /* Rounded corners */
+	cursor: pointer;           /* Pointer cursor on hover */
+}
+.signit-gallery-videos-prev {
+	z-index:1;
+	left : 10%;
+}
+.signit-gallery-videos-next {
+	left : 90%;
+}
 .signit-inline-container {
 	display: flex;
 	align-items: center;

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -251,3 +251,32 @@ html, body {
 	background-image: url( '../icons/down-long-solid.svg' );
 
 }
+.signit-panel-videos {
+    position:relative;
+    text-align: center;
+}
+.signit-panel-videos-gallery{
+    width: 100%;
+}
+.signit-panel-videos-gallery iframe,
+.signit-gallery-videos iframe {
+    box-shadow: 0 0 0.5rem #999;
+    width: 100%;
+    min-height: 220px;
+}
+.signit-gallery-videos-buttons {
+    position : absolute;
+    top:40%;
+    transform : translate(-50%);
+    background-color: white; /* Customize the background color */       
+    border: none;              /* Remove the border */
+    border-radius: 5px;        /* Rounded corners */
+    cursor: pointer;           /* Pointer cursor on hover */
+}
+.signit-gallery-videos-prev {
+	z-index:1;
+	left : 10%;
+}
+.signit-gallery-videos-next {
+	left : 90%;
+}


### PR DESCRIPTION
### Changes made : 

- [bugfix : reset width query parameter from 2700 to 250](https://github.com/lingua-libre/SignIt/commit/49a7f44e1fe1eb575c96992468ab28b0464655da) - this was nothing more than a typo which caused the video dimensions to be unnecessarily large.
- [added overlay buttons](https://github.com/lingua-libre/SignIt/commit/5dfe87e686325d1d47dfcc35c032bbb7eb770808) - as the commit message says , added overlay buttons on top of video. For better user experience , increased the dimensions of video from 250 to 370.
- [refactor : btn positions](https://github.com/lingua-libre/SignIt/commit/d56634b57edfd801c4c145a059d54454bd0e8343) - while the buttons' positions looked good in modal in content script, didn't work as intended in popup. So adjusted `position : relative` accordingly to make it look similar in both popup and modal.

### Challenges faced :

While things worked perfectly fine both in Chrome and FF Popup , they broke in FF Modal. Buttons were appearing at random unwanted positions. When I removed the CSS from `SignItVideosGallery.js` , addressed in [remove : style tag](https://github.com/lingua-libre/SignIt/pull/119/commits/46dfefdf823e919da28c69f584d16b96b8fb5e94) and applied the same in `content_scripts/wpintegration.css` and `popup.css` , addressed in [feat : added CSS for overlay buttons](https://github.com/lingua-libre/SignIt/pull/119/commits/f3a50000cf0e63e6308b114604826f8bcc475e20), the desired styles were applied. **I guess the CSS injected via content scripts as per manifest are superior to internal CSS (which was the case earlier).**

With this #110 can be closed now.